### PR TITLE
Detects changes into repositories divided by init commit

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -9,7 +9,6 @@ import (
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/protocol/packp"
 	"srcd.works/go-errors.v0"
 )
 
@@ -77,7 +76,7 @@ func (a *Archiver) do(j *Job) error {
 		return err
 	}
 
-	changesPerFirstCommit, err := a.getChanges(r.References, gr)
+	changesPerFirstCommit, err := NewChanges(r.References, gr)
 	if err != nil {
 		return err
 	}
@@ -144,12 +143,6 @@ func (a *Archiver) cleanRepoDir(j *Job, dir string) {
 
 func (a *Archiver) createLocalRepository(dir string, j *Job) (*git.Repository, error) {
 	return git.NewFilesystemRepository(dir)
-}
-
-func (a *Archiver) getChanges(oldRefs []*Reference, gr *git.Repository) (
-	map[plumbing.Hash][]*packp.Command, error) {
-	//TODO
-	return map[plumbing.Hash][]*packp.Command{}, nil
 }
 
 func (a *Archiver) notifyStart(j *Job) {

--- a/changes.go
+++ b/changes.go
@@ -1,0 +1,190 @@
+package borges
+
+import (
+	"time"
+
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+// Changes represents several actions to realize to our root repositories. The
+// map key is the hash of a init commit, and the value is a slice of Command
+// that can be add a new reference, delete a reference or update the hash a
+// reference points to.
+type Changes map[SHA1][]*Command
+
+type Action string
+
+const (
+	Create  Action = "create"
+	Update         = "update"
+	Delete         = "delete"
+	Invalid        = "invalid"
+)
+
+// Command is the way to represent a change into a reference. It could be:
+// - Create: A new reference is created
+// - Update: A previous reference is updated. This means its head changes.
+// - Delete: A previous reference does not exist now.
+type Command struct {
+	Old *Reference
+	New *Reference
+}
+
+// Action returns the action related to this command depending of his content
+func (c *Command) Action() Action {
+	if c.Old == nil && c.New == nil {
+		return Invalid
+	}
+
+	if c.Old == nil {
+		return Create
+	}
+
+	if c.New == nil {
+		return Delete
+	}
+
+	return Update
+}
+
+// NewChanges returns Changes needed to obtain the current state of the
+// repository from a set of old references. The Changes could be create,
+// update or delete. It also checks the root commits per each reference.
+// If an old reference has the same name of a new one, but the init commit
+// is different, then the changes will contain a delete command and a
+// create command. If a new reference has more than one init commit, at least
+// one create command per init commit will be created.
+func NewChanges(oldReferences []*Reference, repository *git.Repository) (Changes, error) {
+	refIter, err := repository.References()
+	if err != nil {
+		return nil, err
+	}
+
+	refsByName := refsByName(oldReferences)
+	changes := make(Changes)
+	err = refIter.ForEach(func(r *plumbing.Reference) error {
+		return addChangesBetweenOldAndNewReferences(changes, r, refsByName, repository)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range refsByName {
+		deleteCommand(r, changes)
+	}
+
+	return changes, nil
+}
+
+func addChangesBetweenOldAndNewReferences(
+	c Changes,
+	rReference *plumbing.Reference,
+	oldRefs map[string]*Reference,
+	r *git.Repository) error {
+	now := time.Now()
+
+	if rReference.Type() != plumbing.HashReference || rReference.IsRemote() {
+		return nil
+	}
+
+	roots, err := rootCommits(r, rReference.Hash())
+	if err != nil {
+		return err
+	}
+
+	ref := oldRefs[rReference.Name().String()]
+
+	// If we don't have the reference or the init commit has changed,
+	// we will create a new reference
+	if ref == nil || roots[0] != ref.Init {
+		newReference := &Reference{
+			Name:        rReference.Name().String(),
+			Hash:        SHA1(rReference.Hash()),
+			Init:        roots[0],
+			Roots:       roots,
+			FirstSeenAt: now,
+			UpdatedAt:   now,
+		}
+		newCommand(newReference, c)
+
+		return nil
+	}
+
+	if rReference.Hash() != plumbing.Hash(ref.Hash) {
+		updateReference := &Reference{
+			Name:        rReference.Name().String(),
+			Hash:        SHA1(rReference.Hash()),
+			Init:        roots[0],
+			Roots:       roots,
+			FirstSeenAt: ref.FirstSeenAt,
+			UpdatedAt:   now,
+		}
+		updateCommand(ref, updateReference, c)
+	}
+
+	delete(oldRefs, rReference.Name().String())
+
+	return nil
+}
+
+func deleteCommand(oldR *Reference, c Changes) {
+	addCommand(oldR.Init, &Command{
+		New: nil,
+		Old: oldR,
+	}, c)
+}
+
+func updateCommand(oldR *Reference, newR *Reference, c Changes) {
+	addCommand(oldR.Init, &Command{
+		New: newR,
+		Old: oldR,
+	}, c)
+}
+
+func newCommand(newR *Reference, c Changes) {
+	addCommand(newR.Init, &Command{
+		New: newR,
+		Old: nil,
+	}, c)
+}
+
+func addCommand(ic SHA1, c *Command, changes Changes) {
+	_, ok := changes[ic]
+	if !ok {
+		changes[ic] = make([]*Command, 0)
+	}
+
+	changes[ic] = append(changes[ic], c)
+}
+
+func rootCommits(r *git.Repository, from plumbing.Hash) ([]SHA1, error) {
+	c, err := r.Commit(from)
+	if err != nil {
+		return nil, err
+	}
+
+	var roots []SHA1
+	err = object.WalkCommitHistory(c, func(wc *object.Commit) error {
+		if wc.NumParents() == 0 {
+			roots = append(roots, SHA1(wc.Hash))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return roots, nil
+}
+
+func refsByName(refs []*Reference) map[string]*Reference {
+	result := make(map[string]*Reference)
+	for _, r := range refs {
+		result[r.Name] = r
+	}
+
+	return result
+}

--- a/changes_test.go
+++ b/changes_test.go
@@ -1,0 +1,439 @@
+package borges
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/fixtures"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+)
+
+func TestChangesSuite(t *testing.T) {
+	suite.Run(t, new(ChangesSuite))
+}
+
+type ChangesSuite struct {
+	suite.Suite
+	r     *git.Repository
+	specs []*refFixture
+	aHash string
+	bHash string
+}
+
+func (s *ChangesSuite) SetupSuite() {
+	assert := assert.New(s.T())
+
+	fixtures.Init()
+
+	srcFs := fixtures.ByTag("root-reference").One().DotGit()
+	sto, err := filesystem.NewStorage(srcFs)
+	assert.Nil(err)
+
+	r, err := git.NewRepository(sto)
+	assert.Nil(err)
+	s.r = r
+
+	s.aHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	s.bHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	s.specs = []*refFixture{
+		{
+			Name: "refs/heads/master",
+			Head: "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			Roots: []string{
+				"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+			},
+		}, {
+			Name: "refs/heads/branch",
+			Head: "e8d3ffab552895c19b9fcf7aa264d277cde33881",
+			Roots: []string{
+				"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+			},
+		}, {
+			Name: "refs/heads/1",
+			Head: "caf05fe371a5a6feab588a73ebd9ac73abdd072c",
+			Roots: []string{
+				"8ec19d64748c54c6d047f30c81b4c444a8232b41",
+				"04fffad6eacd4512554cb22ca3a0d6b8a38a96cc",
+				"058cec4b81e8f0a9c3763e0671bbfba0666a4b33",
+			},
+		}, {
+			Name: "refs/heads/2",
+			Head: "04fffad6eacd4512554cb22ca3a0d6b8a38a96cc",
+			Roots: []string{
+				"04fffad6eacd4512554cb22ca3a0d6b8a38a96cc",
+			},
+		}, {
+			Name: "refs/heads/3",
+			Head: "058cec4b81e8f0a9c3763e0671bbfba0666a4b33",
+			Roots: []string{
+				"058cec4b81e8f0a9c3763e0671bbfba0666a4b33",
+			},
+		}, {
+			Name: "refs/heads/functionalityOne",
+			Head: "ca858bfd043ac70bf532d53a4031be0cdf7483b4",
+			Roots: []string{
+				"5e4661353b435315edb0aab7a472bd43c82fed5c",
+			},
+		}, {
+			Name: "refs/heads/functionalityTwo",
+			Head: "79b3db5091672bcb9da2704a2d7b269bcd1ef36f",
+			Roots: []string{
+				"8829746417d76e7a64e540e906abcb7970679e47",
+				"5e4661353b435315edb0aab7a472bd43c82fed5c",
+			},
+		}, {
+			Name: "refs/heads/rootReference",
+			Head: "a135c3e77219a8eaf166a643f6ce3192e97b7e5e",
+			Roots: []string{
+				"a135c3e77219a8eaf166a643f6ce3192e97b7e5e",
+			},
+		}, {
+			Name: "refs/tags/v1.0.0",
+			Head: "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			Roots: []string{
+				"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+			},
+		},
+	}
+}
+
+func (s *ChangesSuite) TearDownSuite() {
+	fixtures.Clean()
+}
+
+func (s *ChangesSuite) TestNewChanges_AllReferencesAreNew() {
+	s.check(&changesTest{
+		Repository:      s.r,
+		InitCommitCount: 7,
+		OldReferences:   nil,
+		Expected: []*refFixture{
+			getByName("refs/heads/master", s.specs).Create(),
+			getByName("refs/heads/branch", s.specs).Create(),
+
+			getByName("refs/heads/1", s.specs).Create(),
+			getByName("refs/heads/2", s.specs).Create(),
+			getByName("refs/heads/3", s.specs).Create(),
+
+			getByName("refs/heads/functionalityOne", s.specs).Create(),
+			getByName("refs/heads/functionalityTwo", s.specs).Create(),
+
+			getByName("refs/heads/rootReference", s.specs).Create(),
+
+			getByName("refs/tags/v1.0.0", s.specs).Create(),
+		},
+	})
+}
+
+func (s *ChangesSuite) TestNewChanges_AllReferencesAreOld() {
+	s.check(&changesTest{
+		Repository:      s.r,
+		InitCommitCount: 0,
+		OldReferences: []*Reference{
+			getByName("refs/heads/master", s.specs).ToRef(),
+			getByName("refs/heads/branch", s.specs).ToRef(),
+
+			getByName("refs/heads/1", s.specs).ToRef(),
+			getByName("refs/heads/2", s.specs).ToRef(),
+			getByName("refs/heads/3", s.specs).ToRef(),
+
+			getByName("refs/heads/functionalityOne", s.specs).ToRef(),
+			getByName("refs/heads/functionalityTwo", s.specs).ToRef(),
+
+			getByName("refs/heads/rootReference", s.specs).ToRef(),
+
+			getByName("refs/tags/v1.0.0", s.specs).ToRef(),
+		},
+		Expected: nil,
+	})
+}
+
+func (s *ChangesSuite) TestNewChanges_TwoOldReferences() {
+	s.check(&changesTest{
+		Repository:      s.r,
+		InitCommitCount: 6,
+		OldReferences: []*Reference{
+			getByName("refs/heads/master", s.specs).ToRef(),
+			getByName("refs/heads/1", s.specs).ToRef(),
+		},
+		Expected: []*refFixture{
+			getByName("refs/heads/branch", s.specs).Create(),
+
+			getByName("refs/heads/2", s.specs).Create(),
+			getByName("refs/heads/3", s.specs).Create(),
+
+			getByName("refs/heads/functionalityOne", s.specs).Create(),
+			getByName("refs/heads/functionalityTwo", s.specs).Create(),
+
+			getByName("refs/heads/rootReference", s.specs).Create(),
+
+			getByName("refs/tags/v1.0.0", s.specs).Create(),
+		},
+	})
+}
+
+func (s *ChangesSuite) TestNewChanges_UpdateAReference() {
+	s.check(&changesTest{
+		Repository:      s.r,
+		InitCommitCount: 7,
+		OldReferences: []*Reference{
+			getByName("refs/heads/master", s.specs).WithHead(s.aHash).ToRef(),
+		},
+		Expected: []*refFixture{
+			getByName("refs/heads/master", s.specs).Update(),
+			getByName("refs/heads/branch", s.specs).Create(),
+
+			getByName("refs/heads/1", s.specs).Create(),
+			getByName("refs/heads/2", s.specs).Create(),
+			getByName("refs/heads/3", s.specs).Create(),
+
+			getByName("refs/heads/functionalityOne", s.specs).Create(),
+			getByName("refs/heads/functionalityTwo", s.specs).Create(),
+
+			getByName("refs/heads/rootReference", s.specs).Create(),
+
+			getByName("refs/tags/v1.0.0", s.specs).Create(),
+		},
+	})
+}
+func (s *ChangesSuite) TestNewChanges_RootCommitChanges() {
+	refRootChange := getByName("refs/heads/master", s.specs).WithRoots(s.aHash)
+
+	s.check(&changesTest{
+		Repository:      s.r,
+		InitCommitCount: 8,
+		OldReferences: []*Reference{
+			refRootChange.ToRef(),
+		},
+		Expected: []*refFixture{
+			refRootChange.Delete(),
+
+			getByName("refs/heads/master", s.specs).Create(),
+			getByName("refs/heads/branch", s.specs).Create(),
+
+			getByName("refs/heads/1", s.specs).Create(),
+			getByName("refs/heads/2", s.specs).Create(),
+			getByName("refs/heads/3", s.specs).Create(),
+
+			getByName("refs/heads/functionalityOne", s.specs).Create(),
+			getByName("refs/heads/functionalityTwo", s.specs).Create(),
+
+			getByName("refs/heads/rootReference", s.specs).Create(),
+
+			getByName("refs/tags/v1.0.0", s.specs).Create(),
+		},
+	})
+}
+
+func (s *ChangesSuite) TestNewChanges_RootCommitsChangeFromTwoToOne() {
+	refRootChange := getByName("refs/heads/master", s.specs).
+		WithRoots(s.aHash, s.bHash)
+
+	s.check(&changesTest{
+		Repository:      s.r,
+		InitCommitCount: 8,
+		OldReferences: []*Reference{
+			refRootChange.ToRef(),
+		},
+		Expected: []*refFixture{
+			getByName("refs/heads/master", s.specs).WithRoots(s.aHash, s.bHash).Delete(),
+
+			getByName("refs/heads/master", s.specs).Create(),
+			getByName("refs/heads/branch", s.specs).Create(),
+
+			getByName("refs/heads/1", s.specs).Create(),
+			getByName("refs/heads/2", s.specs).Create(),
+			getByName("refs/heads/3", s.specs).Create(),
+
+			getByName("refs/heads/functionalityOne", s.specs).Create(),
+			getByName("refs/heads/functionalityTwo", s.specs).Create(),
+
+			getByName("refs/heads/rootReference", s.specs).Create(),
+
+			getByName("refs/tags/v1.0.0", s.specs).Create(),
+		},
+	})
+}
+
+func (s *ChangesSuite) TestNewChanges_EmptyRepository() {
+	s.check(&changesTest{
+		Repository:      git.NewMemoryRepository(),
+		InitCommitCount: 0,
+		OldReferences:   nil,
+		Expected:        nil,
+	})
+}
+
+func (s *ChangesSuite) TestNewChanges_EmptyRepositoryPreviousReferences() {
+	s.check(&changesTest{
+		Repository:      git.NewMemoryRepository(),
+		InitCommitCount: 1,
+		OldReferences: []*Reference{
+			getByName("refs/heads/master", s.specs).ToRef(),
+		},
+		Expected: []*refFixture{
+			getByName("refs/heads/master", s.specs).Delete(),
+		},
+	})
+}
+
+func (s *ChangesSuite) check(ct *changesTest) {
+	assert := assert.New(s.T())
+
+	changes, err := NewChanges(ct.OldReferences, ct.Repository)
+	assert.Nil(err)
+	assert.Equal(ct.InitCommitCount, len(changes))
+
+	for fc, commands := range changes {
+		s.T().Log("InitCommit: ", fc)
+		sbi := withInitCommit(fc, ct.Expected)
+		assert.Equal(len(sbi), len(commands))
+
+		for _, com := range commands {
+			s.T().Log("Command: ", com)
+			rs := getByName(getName(com), sbi)
+			s.T().Log("RefSpec: ", rs)
+			assert.NotNil(rs)
+			assert.Equal(rs.Action, com.Action())
+			switch com.Action() {
+			case Create:
+				assert.Nil(com.Old)
+				assert.Equal(rs.Head, com.New.Hash.String())
+			case Update:
+				assert.Equal(com.Old.Hash, getRefByName(rs.Name, ct.OldReferences).Hash)
+				assert.NotEqual(rs.Head, com.Old.Hash.String())
+				assert.Equal(rs.Head, com.New.Hash.String())
+			case Delete:
+				assert.Nil(com.New)
+				assert.NotNil(com.Old)
+				assert.Equal(rs.Head, com.Old.Hash.String())
+			default:
+				assert.Fail("Unexpected Action value")
+			}
+		}
+	}
+}
+
+type changesTest struct {
+	Repository      *git.Repository
+	InitCommitCount int
+	OldReferences   []*Reference
+	Expected        []*refFixture
+}
+
+type refFixture struct {
+	Name   string
+	Head   string
+	Roots  []string
+	Action Action
+}
+
+func (rs *refFixture) Create() *refFixture {
+	return rs.withAction(Create)
+}
+
+func (rs *refFixture) Update() *refFixture {
+	return rs.withAction(Update)
+}
+
+func (rs *refFixture) Delete() *refFixture {
+	return rs.withAction(Delete)
+}
+
+func (rs *refFixture) withAction(a Action) *refFixture {
+	return &refFixture{
+		Head:   rs.Head,
+		Name:   rs.Name,
+		Action: a,
+		Roots:  rs.Roots,
+	}
+}
+
+func (rs *refFixture) WithHead(hash string) *refFixture {
+	return &refFixture{
+		Head:   hash,
+		Name:   rs.Name,
+		Action: rs.Action,
+		Roots:  rs.Roots,
+	}
+}
+
+func (rs *refFixture) WithRoots(roots ...string) *refFixture {
+	return &refFixture{
+		Head:   rs.Head,
+		Name:   rs.Name,
+		Action: rs.Action,
+		Roots:  roots,
+	}
+}
+
+func (rs *refFixture) ToRef() *Reference {
+	roots := rs.toHash(rs.Roots...)
+	return &Reference{
+		Roots: roots,
+		Init:  roots[0],
+		Hash:  rs.toHash(rs.Head)[0],
+		Name:  rs.Name,
+	}
+}
+
+func (rs *refFixture) toHash(hs ...string) []SHA1 {
+	var result []SHA1
+	for _, h := range hs {
+		b, _ := hex.DecodeString(h)
+		var h SHA1
+		copy(h[:], b)
+
+		result = append(result, h)
+	}
+
+	return result
+}
+
+func withInitCommit(initCommit SHA1, r []*refFixture) []*refFixture {
+	ic := initCommit.String()
+
+	var result []*refFixture
+	for _, sr := range r {
+		if sr.Roots[0] == ic {
+			result = append(result, sr)
+		}
+	}
+
+	return result
+}
+
+func getName(c *Command) string {
+	var name string
+	switch c.Action() {
+	case Create, Update:
+		name = c.New.Name
+	case Delete:
+		name = c.Old.Name
+	}
+
+	return name
+}
+
+func getByName(name string, r []*refFixture) *refFixture {
+	for _, sr := range r {
+		if sr.Name == name {
+			return sr
+		}
+	}
+
+	return nil
+}
+
+func getRefByName(name string, r []*Reference) *Reference {
+	for _, sr := range r {
+		if sr.Name == name {
+			return sr
+		}
+	}
+
+	return nil
+}

--- a/common.go
+++ b/common.go
@@ -1,6 +1,7 @@
 package borges
 
 import (
+	"encoding/hex"
 	"time"
 
 	"srcd.works/go-errors.v0"
@@ -77,3 +78,8 @@ type Reference struct {
 
 // SHA1 is a SHA-1 hash.
 type SHA1 [20]byte
+
+// String represetnation from this SHA1
+func (h SHA1) String() string {
+	return hex.EncodeToString(h[:])
+}


### PR DESCRIPTION
We need to obtain the current state of the repository from a set of old references. To do this, we will use a list of changes to do per each first commit. These first commits represents our root repository, the way we will organize all the source code for all the repositories. The Changes could be create, update or delete.