### PR TITLE
Get models from srcd.works/core.v0/models

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"srcd.works/core.v0/models"
 	"srcd.works/go-billy.v1/osfs"
 	"srcd.works/go-errors.v0"
 	"srcd.works/go-git.v4"
@@ -94,10 +95,10 @@ func (a *Archiver) do(j *Job) error {
 	return nil
 }
 
-func (a *Archiver) getRepositoryModel(j *Job) (*Repository, error) {
+func (a *Archiver) getRepositoryModel(j *Job) (*models.Repository, error) {
 	//TODO: if id == 0 { generate new repository with URL }
 	//      else { get from DB }
-	return &Repository{ID: j.RepositoryID}, nil
+	return &models.Repository{}, nil
 }
 
 func (a *Archiver) newRepoDir(j *Job) (string, error) {
@@ -142,7 +143,7 @@ func (a *Archiver) notifyWarn(j *Job, err error) {
 // hardcoded into his storage. This is intended to be able to do a partial fetch.
 // Having the references into the storage we will only download new objects, not
 // the entire repository.
-func createLocalRepository(dir string, j *Job, refs []*Reference) (*git.Repository, error) {
+func createLocalRepository(dir string, j *Job, refs []*models.Reference) (*git.Repository, error) {
 	s, err := filesystem.NewStorage(osfs.New(dir))
 	if err != nil {
 		return nil, err
@@ -168,7 +169,7 @@ func createLocalRepository(dir string, j *Job, refs []*Reference) (*git.Reposito
 	return r, nil
 }
 
-func setReferences(s storer.ReferenceStorer, refs ...*Reference) error {
+func setReferences(s storer.ReferenceStorer, refs ...*models.Reference) error {
 	for _, ref := range refs {
 		if err := s.SetReference(ref.GitReference()); err != nil {
 			return err

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/src-d/go-git-fixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"srcd.works/core.v0/models"
 	"srcd.works/go-git.v4"
 	"srcd.works/go-git.v4/plumbing"
 	"srcd.works/go-git.v4/plumbing/object"
@@ -54,16 +55,16 @@ func (s *ArchiverSuite) TearDownSuite() {
 func (s *ArchiverSuite) TestCreateLocalRepository() {
 	assert := assert.New(s.T())
 
-	repo, err := createLocalRepository(s.tmpDir, s.j, []*Reference{
+	repo, err := createLocalRepository(s.tmpDir, s.j, []*models.Reference{
 		{
-			Hash: NewSHA1("918c48b83bd081e863dbe1b80f8998f058cd8294"),
+			Hash: models.NewSHA1("918c48b83bd081e863dbe1b80f8998f058cd8294"),
 			Name: "refs/remotes/origin/master",
-			Init: NewSHA1("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
+			Init: models.NewSHA1("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
 		}, {
 			// branch is up to date
-			Hash: NewSHA1("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
+			Hash: models.NewSHA1("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
 			Name: "refs/remotes/origin/branch",
-			Init: NewSHA1("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
+			Init: models.NewSHA1("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
 		},
 	})
 	assert.Nil(err)

--- a/changes_test.go
+++ b/changes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"srcd.works/core.v0/models"
 	"srcd.works/go-billy.v1/memfs"
 	"srcd.works/go-git.v4"
 	"srcd.works/go-git.v4/storage/filesystem"
@@ -136,7 +137,7 @@ func (s *ChangesSuite) TestNewChanges_AllReferencesAreOld() {
 	s.check(&changesTest{
 		Repository:      s.r,
 		InitCommitCount: 0,
-		OldReferences: []*Reference{
+		OldReferences: []*models.Reference{
 			getByName("refs/heads/master", s.specs).ToRef(),
 			getByName("refs/heads/branch", s.specs).ToRef(),
 
@@ -159,7 +160,7 @@ func (s *ChangesSuite) TestNewChanges_TwoOldReferences() {
 	s.check(&changesTest{
 		Repository:      s.r,
 		InitCommitCount: 6,
-		OldReferences: []*Reference{
+		OldReferences: []*models.Reference{
 			getByName("refs/heads/master", s.specs).ToRef(),
 			getByName("refs/heads/1", s.specs).ToRef(),
 		},
@@ -183,7 +184,7 @@ func (s *ChangesSuite) TestNewChanges_UpdateAReference() {
 	s.check(&changesTest{
 		Repository:      s.r,
 		InitCommitCount: 7,
-		OldReferences: []*Reference{
+		OldReferences: []*models.Reference{
 			getByName("refs/heads/master", s.specs).WithHead(s.aHash).ToRef(),
 		},
 		Expected: []*refFixture{
@@ -209,7 +210,7 @@ func (s *ChangesSuite) TestNewChanges_RootCommitChanges() {
 	s.check(&changesTest{
 		Repository:      s.r,
 		InitCommitCount: 8,
-		OldReferences: []*Reference{
+		OldReferences: []*models.Reference{
 			refRootChange.ToRef(),
 		},
 		Expected: []*refFixture{
@@ -239,7 +240,7 @@ func (s *ChangesSuite) TestNewChanges_RootCommitsChangeFromTwoToOne() {
 	s.check(&changesTest{
 		Repository:      s.r,
 		InitCommitCount: 8,
-		OldReferences: []*Reference{
+		OldReferences: []*models.Reference{
 			refRootChange.ToRef(),
 		},
 		Expected: []*refFixture{
@@ -275,7 +276,7 @@ func (s *ChangesSuite) TestNewChanges_EmptyRepositoryPreviousReferences() {
 	s.check(&changesTest{
 		Repository:      newEmptyRepository(),
 		InitCommitCount: 1,
-		OldReferences: []*Reference{
+		OldReferences: []*models.Reference{
 			getByName("refs/heads/master", s.specs).ToRef(),
 		},
 		Expected: []*refFixture{
@@ -327,7 +328,7 @@ func (s *ChangesSuite) check(ct *changesTest) {
 type changesTest struct {
 	Repository      *git.Repository
 	InitCommitCount int
-	OldReferences   []*Reference
+	OldReferences   []*models.Reference
 	Expected        []*refFixture
 }
 
@@ -377,9 +378,9 @@ func (rs *refFixture) WithRoots(roots ...string) *refFixture {
 	}
 }
 
-func (rs *refFixture) ToRef() *Reference {
+func (rs *refFixture) ToRef() *models.Reference {
 	roots := rs.toHash(rs.Roots...)
-	return &Reference{
+	return &models.Reference{
 		Roots: roots,
 		Init:  roots[0],
 		Hash:  rs.toHash(rs.Head)[0],
@@ -387,11 +388,11 @@ func (rs *refFixture) ToRef() *Reference {
 	}
 }
 
-func (rs *refFixture) toHash(hs ...string) []SHA1 {
-	var result []SHA1
+func (rs *refFixture) toHash(hs ...string) []models.SHA1 {
+	var result []models.SHA1
 	for _, h := range hs {
 		b, _ := hex.DecodeString(h)
-		var h SHA1
+		var h models.SHA1
 		copy(h[:], b)
 
 		result = append(result, h)
@@ -400,7 +401,7 @@ func (rs *refFixture) toHash(hs ...string) []SHA1 {
 	return result
 }
 
-func withInitCommit(initCommit SHA1, r []*refFixture) []*refFixture {
+func withInitCommit(initCommit models.SHA1, r []*refFixture) []*refFixture {
 	ic := initCommit.String()
 
 	var result []*refFixture
@@ -435,7 +436,7 @@ func getByName(name string, r []*refFixture) *refFixture {
 	panic("not found: " + name)
 }
 
-func getRefByName(name string, r []*Reference) *Reference {
+func getRefByName(name string, r []*models.Reference) *models.Reference {
 	for _, sr := range r {
 		if sr.Name == name {
 			return sr

--- a/common.go
+++ b/common.go
@@ -1,12 +1,9 @@
 package borges
 
 import (
-	"encoding/hex"
 	"io"
-	"time"
 
 	"srcd.works/go-errors.v0"
-	"srcd.works/go-git.v4/plumbing"
 )
 
 var (
@@ -30,85 +27,4 @@ type JobIter interface {
 	// jobs. If there are no more jobs at the moment, but there can be
 	// in the future, it returns an error of kind ErrWaitForJobs.
 	Next() (*Job, error)
-}
-
-// Repository represents a remote repository found on the Internet.
-type Repository struct {
-	// ID is a unique identifier.
-	ID uint64
-	// Endpoints is a slice of valid git endpoints to reach this repository.
-	// For example, git://host/my/repo.git and https://host/my/repo.git.
-	// They are meant to be endpoints of the same exact repository, and not
-	// mirrors.
-	Endpoints []string
-	// Status is the fetch status of tge repository in our repository storage.
-	Status FetchStatus
-	// CreatedAt is the timestamp of the creation of this record.
-	CreatedAt time.Time
-	// FetchedAt is the timestamp of the last time this repository was
-	// fetched and archived in our repository storage successfully.
-	FetchedAt time.Time
-	// FetchErrorAt is the timestamp of the last fetch error, if any.
-	FetchErrorAt time.Time
-	// LastCommitAt is the last commit time found in this repository.
-	LastCommitAat time.Time
-	// References is the current slice of references as present in our
-	// repository storage.
-	References []*Reference
-}
-
-// FetchStatus represents the fetch status of this repository.
-type FetchStatus string
-
-const (
-	// NotFound means that the remote repository was not found at the given
-	// endpoints.
-	NotFound FetchStatus = "not_found"
-	// Fetched means that the remote repository was found, fetched and
-	// successfully stored.
-	Fetched = "fetched"
-	// Pending is the default value, meaning that the repository has not
-	// been fetched yet.
-	Pending = "pending"
-)
-
-// Reference is a reference of a repository as present in our repository storage.
-type Reference struct {
-	// Name is the full reference name.
-	Name string
-	// Hash is the hash of the reference.
-	Hash SHA1
-	// Init is the hash of the init commit reached from this reference.
-	Init SHA1
-	// Roots is a slice of the hashes of all root commits reachable from
-	// this reference.
-	Roots []SHA1
-	// UpdatedAt is the timestamp of the last time we updated this reference.
-	UpdatedAt time.Time
-	// FirstSeenAt is the timestamp of the first time we saw this reference.
-	FirstSeenAt time.Time
-}
-
-func (r *Reference) GitReference() *plumbing.Reference {
-	return plumbing.NewHashReference(
-		plumbing.ReferenceName(r.Name),
-		plumbing.Hash(r.Hash),
-	)
-}
-
-// SHA1 is a SHA-1 hash.
-type SHA1 [20]byte
-
-func NewSHA1(s string) SHA1 {
-	b, _ := hex.DecodeString(s)
-
-	var h SHA1
-	copy(h[:], b)
-
-	return h
-}
-
-// String representation from this SHA1
-func (h SHA1) String() string {
-	return hex.EncodeToString(h[:])
 }


### PR DESCRIPTION
To be able to have a common domain, we deleted from borges all the model objects, and now we get it from a common library, in this case called core.