### PR TITLE
Update to go-errors migration to gopkg.in

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/src-d/go-billy.v3"
 	"gopkg.in/src-d/go-billy.v3/util"
+	"gopkg.in/src-d/go-errors.v0"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -21,7 +22,6 @@ import (
 	"gopkg.in/src-d/go-kallax.v1"
 	"srcd.works/core-retrieval.v0/repository"
 	"srcd.works/core.v0/model"
-	"srcd.works/go-errors.v0"
 )
 
 var (

--- a/common.go
+++ b/common.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/satori/go.uuid"
+	"gopkg.in/src-d/go-errors.v0"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-kallax.v1"
 	"srcd.works/core.v0"
 	"srcd.works/core.v0/model"
-	"srcd.works/go-errors.v0"
 )
 
 var (

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -416,7 +416,7 @@ var ChangesFixtures = []*ChangesFixture{{
 	},
 }, {
 	FakeHashes: true,
-	TestName: "all reference are new except one (updated with new init)",
+	TestName:   "all reference are new except one (updated with new init)",
 	OldReferences: []*model.Reference{
 		withRoots(
 			withHash(model.NewSHA1("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
@@ -457,7 +457,7 @@ var ChangesFixtures = []*ChangesFixture{{
 	},
 }, {
 	FakeHashes: true,
-	TestName: "all reference are new except one (one root removed)",
+	TestName:   "all reference are new except one (one root removed)",
 	OldReferences: []*model.Reference{
 		withRoots(
 			withHash(model.NewSHA1("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),

--- a/linejobiter_test.go
+++ b/linejobiter_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/satori/go.uuid"
-	"gopkg.in/src-d/go-kallax.v1"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-kallax.v1"
 	"srcd.works/core.v0"
 	"srcd.works/core.v0/model"
 )


### PR DESCRIPTION
Merge #35 and https://github.com/src-d/go-errors/pull/6 first.

Part of https://github.com/src-d/backlog/issues/700.