### PR TITLE
producer: index endpoints array column.

### DIFF
--- a/common.go
+++ b/common.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 
 	"github.com/satori/go.uuid"
+	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-kallax.v1"
 	"srcd.works/core.v0"
 	"srcd.works/core.v0/model"
 	"srcd.works/go-errors.v0"
-	"gopkg.in/src-d/go-git.v4"
 )
 
 var (
@@ -78,6 +78,14 @@ func DropTables(names ...string) {
 	}
 }
 
+// TODO temporal
+func DropIndexes(names ...string) {
+	smt := fmt.Sprintf("DROP INDEX IF EXISTS %s;", strings.Join(names, ", "))
+	if _, err := core.Database().Exec(smt); err != nil {
+		panic(err)
+	}
+}
+
 // TODO temporal delete when kallax implements it
 func CreateRepositoryTable() {
 	_, err := core.Database().Exec(`CREATE TABLE IF NOT EXISTS repositories (
@@ -90,7 +98,8 @@ func CreateRepositoryTable() {
 	fetch_error_at timestamptz,
 	last_commit_at timestamptz,
 	_references jsonb
-	)`)
+	);
+	CREATE INDEX idx_endpoints on "repositories" USING GIN ("endpoints");`)
 
 	if err != nil {
 		panic(err)

--- a/linejobiter_test.go
+++ b/linejobiter_test.go
@@ -69,6 +69,7 @@ func TestLineJobIterNonAbsoluteURL(t *testing.T) {
 	r := ioutil.NopCloser(strings.NewReader(text))
 
 	DropTables("repository")
+	DropIndexes("idx_endpoints")
 	CreateRepositoryTable()
 	storer := core.ModelRepositoryStore()
 
@@ -94,6 +95,7 @@ func TestLineJobIterBadURL(t *testing.T) {
 	r := ioutil.NopCloser(strings.NewReader(text))
 
 	DropTables("repository")
+	DropIndexes("idx_endpoints")
 	CreateRepositoryTable()
 	storer := core.ModelRepositoryStore()
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -36,6 +36,7 @@ func (s *ProducerSuite) SetupSuite() {
 
 func (s *ProducerSuite) newProducer() *Producer {
 	DropTables("repository")
+	DropIndexes("idx_endpoints")
 	CreateRepositoryTable()
 	storer := core.ModelRepositoryStore()
 


### PR DESCRIPTION
Borges producer executes a a query per mention obtained from rovers, to generate an unique repository index.
To improve this query, is necessary an index on the endpoints column.

It fixes #28