### PR TITLE
Failed repos go to a dead-letter queue

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -71,7 +71,7 @@ func (c *Consumer) backoff() {
 
 func (c *Consumer) reject(j *queue.Job, origErr error) {
 	c.notifyQueueError(origErr)
-	if err := j.Reject(true); err != nil {
+	if err := j.Reject(false); err != nil {
 		c.notifyQueueError(err)
 	}
 }

--- a/producer_test.go
+++ b/producer_test.go
@@ -2,14 +2,15 @@ package borges
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"srcd.works/core.v0"
 	rmodel "srcd.works/core-retrieval.v0/model"
+	"srcd.works/core.v0"
 	"srcd.works/framework.v0/queue"
 )
 
@@ -28,7 +29,7 @@ func (s *ProducerSuite) SetupSuite() {
 	s.BaseQueueSuite.SetupSuite()
 
 	assert := require.New(s.T())
-	q, err := s.broker.Queue("mentions_test")
+	q, err := s.broker.Queue(fmt.Sprintf("mentions_test_%d", time.Now().UnixNano()))
 	assert.NoError(err)
 
 	s.mentionsQueue = q


### PR DESCRIPTION
Instead of re-queue again and again failed repositories, now we are sending this jobs to a dead-letter queue, to be able to try to reprocess them in the future.

Fixes #26 