### PR TITLE
test: Do not re-queue worker jobs

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -60,6 +60,9 @@ func (s *ConsumerSuite) TestConsumer_StartStop_FailedJob() {
 	require.NoError(timeoutChan(done, time.Second*10))
 	require.Equal(1, processed)
 
+	require.Error(timeoutChan(done, time.Second*5))
+	require.Equal(1, processed)
+
 	err := s.queue.RepublishBuried()
 	require.NoError(err)
 

--- a/worker.go
+++ b/worker.go
@@ -39,7 +39,7 @@ func (w *Worker) Start() {
 			}
 
 			if err := w.do(w.ctx, job.Job); err != nil {
-				if err := job.Reject(true); err != nil {
+				if err := job.Reject(false); err != nil {
 					log.Error("error rejecting job", "err", err)
 				}
 


### PR DESCRIPTION
If they fail, they should go to the dead-letter queue.