### PR TITLE
Fix "reference not found error"

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -1,7 +1,6 @@
 package borges
 
 import (
-	"errors"
 	"time"
 
 	"gopkg.in/src-d/core.v0/model"
@@ -51,8 +50,6 @@ func (c *Command) Action() Action {
 
 	return Update
 }
-
-var ErrReferencedObjectTypeNotSupported error = errors.New("referenced object type not supported")
 
 // NewChanges returns Changes needed to obtain the current state of the
 // repository from a set of old references. The Changes could be create,
@@ -183,7 +180,7 @@ func (c Changes) Add(new *model.Reference) {
 }
 
 func rootCommits(r *git.Repository, from plumbing.Hash) ([]model.SHA1, error) {
-	h, err := resolveHash(r, from)
+	h, err := ResolveHash(r, from)
 	if err != nil {
 		return nil, err
 	}
@@ -204,23 +201,6 @@ func rootCommits(r *git.Repository, from plumbing.Hash) ([]model.SHA1, error) {
 	})
 
 	return roots, err
-}
-
-func resolveHash(r *git.Repository, h plumbing.Hash) (plumbing.Hash, error) {
-	obj, err := r.Object(plumbing.AnyObject, h)
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
-
-	switch o := obj.(type) {
-	case *object.Commit:
-		return o.Hash, nil
-	case *object.Tag:
-		return resolveHash(r, o.Target)
-	default:
-		log.Warn("referenced object not supported", "type", o.Type())
-		return plumbing.ZeroHash, ErrReferencedObjectTypeNotSupported
-	}
 }
 
 func refsByName(refs []*model.Reference) map[string]*model.Reference {


### PR DESCRIPTION
Repositories with no 'master' branch were failing because, trying to get the last commit date,  we had been trying to get a master reference that does not exists.
Now the logic is a little bit different: We iterate over all hash references, getting the date of each Commit that are pointing to. We return the newest date.
References that are pointing to Tags are resolved. References pointing to Objects that are not Commits or Tags are ignored, printing a warning on logs.

Fix #72 