### PR TITLE
update to latest core-retrieval.v0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 784a506b0d75c0f8b81288909ac4e9c02b34d3eba61dbb9874093cd77ff0dbe2
-updated: 2017-07-06T16:15:13.623459938+02:00
+hash: 0f9c5db00b423aba66d034e150c6f6bcdcb780829943d6be3842feb45f2ca955
+updated: 2017-07-06T17:40:29.174263408+02:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
@@ -102,7 +102,7 @@ imports:
   - bson
   - internal/json
 - name: gopkg.in/src-d/core-retrieval.v0
-  version: 0f889725e717bdc83045700bb73409b27c8f7b6e
+  version: 0e589118a5430a6efc811a69a18132918f070945
   subpackages:
   - model
   - repository
@@ -113,8 +113,8 @@ imports:
   - configurable
   - database
   - queue
-- name: gopkg.in/src-d/go-billy-siva.v2
-  version: ef50766c721fc7b2e762adf537d5556d86f6f1af
+- name: gopkg.in/src-d/go-billy-siva.v3
+  version: b15b35bba22ab049715a74125fb100faee83cd00
 - name: gopkg.in/src-d/go-billy.v3
   version: c329b7bc7b9d24905d2bc1b85bfa29f7ae266314
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,7 +24,7 @@ import:
 - package: gopkg.in/src-d/go-kallax.v1
   version: ^1.2.7
 - package: gopkg.in/src-d/core-retrieval.v0
-  version: 0f889725e717bdc83045700bb73409b27c8f7b6e
+  version: 0e589118a5430a6efc811a69a18132918f070945
   subpackages:
   - model
   - repository


### PR DESCRIPTION
This brings us:
* https://github.com/src-d/go-billy-siva/pull/12
* https://github.com/src-d/core-retrieval/pull/21
which should avoid conflicts on temporary files.