### PR TITLE
Fix updateReferences method

### DIFF
--- a/archiver_test.go
+++ b/archiver_test.go
@@ -55,14 +55,13 @@ func (s *ArchiverSuite) TestReferenceUpdate() {
 	for _, ct := range ChangesFixtures {
 		if ct.FakeHashes {
 			s.T().Run(ct.TestName, func(t *testing.T) {
-				assert := assert.New(t)
-
-				references := ct.OldReferences
-				for _, cs := range ct.Changes { // emulate pushChangesToRootedRepositories() behaviour
-					references = updateRepositoryReferences(references, cs)
+				var obtainedRefs []*model.Reference
+				for ic, cs := range ct.Changes { // emulate pushChangesToRootedRepositories() behaviour
+					or := updateRepositoryReferences(ct.OldReferences, cs, ic)
+					obtainedRefs = append(obtainedRefs, or...)
 				}
 
-				assert.Equal(len(ct.NewReferences), len(references))
+				s.Equal(len(ct.NewReferences), len(obtainedRefs))
 			})
 		}
 	}
@@ -75,6 +74,10 @@ func (s *ArchiverSuite) TestFixtures() {
 		}
 
 		s.T().Run(ct.TestName, func(t *testing.T) {
+			if ct.TestName ==  "one existing reference is removed (output with references)" {
+				t.Skip("go-git bug: https://github.com/src-d/go-git/issues/466")
+			}
+
 			require := require.New(t)
 			assert := assert.New(t)
 

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -276,11 +276,29 @@ var ChangesFixtures = []*ChangesFixture{{
 	NewReferences: nil,
 	Changes:       Changes{},
 }, {
-	TestName: "one existing reference is removed",
+	TestName: "one existing reference is removed (output with no references)",
 	OldReferences: []*model.Reference{
 		fixtureReferences.ByName("refs/heads/master"),
 	},
 	NewReferences: nil,
+	Changes: Changes{
+		model.NewSHA1("b029517f6300c2da0f4b651b8642506cd6aaf45d"): []*Command{
+			testDeleteCommand(fixtureReferences.ByName("refs/heads/master")),
+		},
+	},
+}, {
+	TestName:      "one existing reference is removed (output with references)",
+	OldReferences: defaultReferences,
+	NewReferences: []*model.Reference{
+		fixtureReferences.ByName("refs/heads/branch"),
+		fixtureReferences.ByName("refs/heads/1"),
+		fixtureReferences.ByName("refs/heads/2"),
+		fixtureReferences.ByName("refs/heads/3"),
+		fixtureReferences.ByName("refs/heads/functionalityOne"),
+		fixtureReferences.ByName("refs/heads/functionalityTwo"),
+		fixtureReferences.ByName("refs/heads/rootReference"),
+		fixtureReferences.ByName("refs/tags/v1.0.0"),
+	},
 	Changes: Changes{
 		model.NewSHA1("b029517f6300c2da0f4b651b8642506cd6aaf45d"): []*Command{
 			testDeleteCommand(fixtureReferences.ByName("refs/heads/master")),


### PR DESCRIPTION
We need to take into account the initCommit to be able to update correctly the references, not only by the reference name.

- Added a new test dropping one reference going from 9 to 8
- Ignoring archiver test due to bug in go-git: src-d/go-git#466