### PR TITLE
changes: abstract away code to iterate references

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -135,7 +135,9 @@ func (a *Archiver) do(j *Job) error {
 		return finalErr
 	}
 
-	changes, err := NewChanges(r.References, gr)
+	oldRefs := NewModelReferencer(r)
+	newRefs := NewGitReferencer(gr)
+	changes, err := NewChanges(oldRefs, newRefs)
 	if err != nil {
 		return err
 	}

--- a/changes_test.go
+++ b/changes_test.go
@@ -5,23 +5,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/src-d/go-git-fixtures"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/core-retrieval.v0/model"
-	"gopkg.in/src-d/go-billy.v3/memfs"
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
 
 func TestNewChanges(t *testing.T) {
-	fixtures.Init()
-	defer fixtures.Clean()
 	for _, ct := range ChangesFixtures {
 		t.Run(ct.TestName, func(t *testing.T) {
 			require := require.New(t)
-			sto, err := ct.NewRepository()
-			require.NoError(err)
-			changes, err := newChanges(timeNow, ct.OldReferences, sto)
+			oldRefs := NewModelReferencer(&model.Repository{References: ct.OldReferences})
+			newRefs := NewModelReferencer(&model.Repository{References: ct.NewReferences})
+			changes, err := newChanges(timeNow, oldRefs, newRefs)
 			require.NoError(err)
 
 			sortChanges(changes)
@@ -29,32 +23,6 @@ func TestNewChanges(t *testing.T) {
 
 			require.Equal(ct.Changes, changes)
 		})
-	}
-}
-
-func TestChanges_ReferenceToTagObject(t *testing.T) {
-	fixtures.Init()
-	defer fixtures.Clean()
-	require := require.New(t)
-
-	srcFs := fixtures.ByTag("tags").One().DotGit()
-	sto, err := filesystem.NewStorage(srcFs)
-	require.NoError(err)
-
-	r, err := git.Open(sto, memfs.New())
-	require.NoError(err)
-
-	changes, err := newChanges(timeNow, nil, r)
-	require.NoError(err)
-
-	require.Equal(1, len(changes))
-	for k, v := range changes {
-		require.Equal(model.NewSHA1("f7b877701fbf855b44c0a9e86f3fdce2c298b07f"), k)
-		for _, c := range v {
-			require.Equal(Create, c.Action())
-		}
-
-		require.Equal(4, len(v))
 	}
 }
 

--- a/common.go
+++ b/common.go
@@ -134,3 +134,9 @@ func CreateRepositoryTable() {
 		panic(err)
 	}
 }
+
+// Referencer can retrieve reference models (*model.Reference).
+type Referencer interface {
+	// References retrieves a slice of *model.Reference or an error.
+	References() ([]*model.Reference, error)
+}

--- a/git.go
+++ b/git.go
@@ -1,0 +1,76 @@
+package borges
+
+import (
+	"gopkg.in/src-d/core-retrieval.v0/model"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+// NewGitReferencer takes a *git.Repository and returns a Referencer that
+// retrieves any valid reference from it. Symbolic references and references
+// that do not point to commits (possibly through a tag) are silently ignored.
+// It might return an error if any operation fails in the underlying repository.
+func NewGitReferencer(r *git.Repository) Referencer {
+	return gitReferencer{r}
+}
+
+type gitReferencer struct {
+	*git.Repository
+}
+
+func (r gitReferencer) References() ([]*model.Reference, error) {
+	iter, err := r.Repository.References()
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []*model.Reference
+	return refs, iter.ForEach(func(ref *plumbing.Reference) error {
+		//TODO: add tags support
+		if ref.Type() != plumbing.HashReference || ref.IsRemote() {
+			return nil
+		}
+
+		h, err := ResolveHash(r.Repository, plumbing.NewHash(ref.Hash().String()))
+		if err == ErrReferencedObjectTypeNotSupported {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		roots, err := rootCommits(r.Repository, h)
+		if err != nil {
+			return err
+		}
+
+		refs = append(refs, &model.Reference{
+			Name:  ref.Name().String(),
+			Hash:  model.NewSHA1(ref.Hash().String()),
+			Init:  roots[0],
+			Roots: roots,
+		})
+		return nil
+	})
+}
+
+func rootCommits(r *git.Repository, from plumbing.Hash) ([]model.SHA1, error) {
+	var roots []model.SHA1
+
+	cIter, err := r.Log(&git.LogOptions{From: from})
+	if err != nil {
+		return nil, err
+	}
+
+	err = cIter.ForEach(func(wc *object.Commit) error {
+		if wc.NumParents() == 0 {
+			roots = append(roots, model.SHA1(wc.Hash))
+		}
+
+		return nil
+	})
+
+	return roots, err
+}

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,62 @@
+package borges
+
+import (
+	"testing"
+
+	"github.com/src-d/go-git-fixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-billy.v3/memfs"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+)
+
+func TestNewGitReferencer(t *testing.T) {
+	fixtures.Init()
+	defer fixtures.Clean()
+
+	for _, ct := range ChangesFixtures {
+		t.Run(ct.TestName, func(t *testing.T) {
+			assert := assert.New(t)
+			r, err := ct.NewRepository()
+			assert.NoError(err)
+
+			gitRefs := NewGitReferencer(r)
+			resGitRefs, err := gitRefs.References()
+			assert.NoError(err)
+			assert.Equal(len(ct.NewReferences), len(resGitRefs))
+
+			resGitRefsByName := refsByName(resGitRefs)
+			expectedRefsByName := refsByName(ct.NewReferences)
+			for name, expectedRef := range expectedRefsByName {
+				obtainedRef, ok := resGitRefsByName[name]
+				assert.True(ok)
+				assert.Equal(expectedRef.Name, obtainedRef.Name)
+				assert.Equal(expectedRef.Hash, obtainedRef.Hash)
+				assert.Equal(expectedRef.Init, obtainedRef.Init)
+				assert.Equal(expectedRef.Roots, obtainedRef.Roots)
+			}
+		})
+	}
+}
+
+func TestNewGitReferencer_ReferenceToTagObject(t *testing.T) {
+	fixtures.Init()
+	defer fixtures.Clean()
+	require := require.New(t)
+
+	srcFs := fixtures.ByTag("tags").One().DotGit()
+	sto, err := filesystem.NewStorage(srcFs)
+	require.NoError(err)
+
+	r, err := git.Open(sto, memfs.New())
+	require.NoError(err)
+
+	newRefs := NewGitReferencer(r)
+	refs, err := newRefs.References()
+	require.NoError(err)
+	require.Len(refs, 4)
+	for _, ref := range refs {
+		require.Equal("f7b877701fbf855b44c0a9e86f3fdce2c298b07f", ref.Init.String())
+	}
+}

--- a/model.go
+++ b/model.go
@@ -1,0 +1,17 @@
+package borges
+
+import "gopkg.in/src-d/core-retrieval.v0/model"
+
+// NewModelReferencer takes a *model.Repository and returns a Referencer that
+// accesses its references. The resulting Referencer never returns an error.
+func NewModelReferencer(r *model.Repository) Referencer {
+	return modelReferencer{r}
+}
+
+type modelReferencer struct {
+	*model.Repository
+}
+
+func (r modelReferencer) References() ([]*model.Reference, error) {
+	return r.Repository.References, nil
+}

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,20 @@
+package borges
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/core-retrieval.v0/model"
+)
+
+func TestNewModelReferencer(t *testing.T) {
+	for _, ct := range ChangesFixtures {
+		t.Run(ct.TestName, func(t *testing.T) {
+			require := require.New(t)
+			refs := NewModelReferencer(&model.Repository{References: ct.NewReferences})
+			res, err := refs.References()
+			require.NoError(err)
+			require.Equal(ct.NewReferences, res)
+		})
+	}
+}


### PR DESCRIPTION
* Introduce a new interface Referencer to retrieve references
  with implementations for *model.Repository and *git.Repository.
* Now NewChanges just takes two Referencers to compare, removing
  all logic specif to database access or go-git.