### PR TITLE
Add profiling capabilities to consumer and producer

### DIFF
--- a/cli/borges/consumer.go
+++ b/cli/borges/consumer.go
@@ -19,6 +19,7 @@ type consumerCmd struct {
 
 func (c *consumerCmd) Execute(args []string) error {
 	c.ChangeLogLevel()
+	c.startProfilingHTTPServerMaybe(c.ProfilerPort)
 
 	b := core.Broker()
 	defer b.Close()

--- a/cli/borges/producer.go
+++ b/cli/borges/producer.go
@@ -26,6 +26,7 @@ type producerCmd struct {
 
 func (c *producerCmd) Execute(args []string) error {
 	c.ChangeLogLevel()
+	c.startProfilingHTTPServerMaybe(c.ProfilerPort + 1)
 
 	b := core.Broker()
 	defer b.Close()
@@ -43,6 +44,7 @@ func (c *producerCmd) Execute(args []string) error {
 	p := borges.NewProducer(ji, q)
 	p.Notifiers.Done = c.notifier
 	p.Start()
+
 	return err
 }
 


### PR DESCRIPTION
 - [x] ~producer: add `--cpuprofile` and `--memprofile` CLI flags to save profiles to FS~
 - [x] consumer: add `--profiler` flag to expose profiler data over HTTP

_Update_
 - [x] investigate migration to https://github.com/pkg/profile (suitable only for processes with short lifetime, to write profiles to a file on exit)
 - [x] change `borges producer` to HTTP as it's a long-running service exposing `--profiler` and `--profiler-port`