### PR TITLE
logging: propagate logger instance and context

### DIFF
--- a/archiver_test.go
+++ b/archiver_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inconshreveable/log15"
 	"github.com/satori/go.uuid"
 	"github.com/src-d/go-git-fixtures"
 	"github.com/stretchr/testify/require"
@@ -67,10 +68,7 @@ func (s *ArchiverSuite) SetupTest() {
 	})
 	s.NoError(err)
 
-	s.a = NewArchiver(s.store, s.tx, NewTemporaryCloner(s.tmpFs), ls)
-	s.a.Notifiers.Warn = func(j *Job, err error) {
-		s.NoError(err, "job: %v", j)
-	}
+	s.a = NewArchiver(log15.New(), s.store, s.tx, NewTemporaryCloner(s.tmpFs), ls)
 }
 
 func (s *ArchiverSuite) TearDownTest() {

--- a/cli/borges/consumer.go
+++ b/cli/borges/consumer.go
@@ -29,36 +29,16 @@ func (c *consumerCmd) Execute(args []string) error {
 	}
 
 	wp := borges.NewArchiverWorkerPool(
+		log,
 		core.ModelRepositoryStore(),
 		core.RootedTransactioner(),
 		borges.NewTemporaryCloner(core.TemporaryFilesystem()),
 		core.Locking(),
-		c.startNotifier, c.stopNotifier, c.warnNotifier)
+	)
 	wp.SetWorkerCount(c.WorkersCount)
 
 	ac := borges.NewConsumer(q, wp)
-	ac.Notifiers.QueueError = c.queueErrorNotifier
 	ac.Start()
 
 	return nil
-}
-
-func (c *consumerCmd) startNotifier(ctx *borges.WorkerContext, j *borges.Job) {
-	log.Debug("job started", "WorkerID", ctx.ID, "RepositoryID", j.RepositoryID)
-}
-
-func (c *consumerCmd) stopNotifier(ctx *borges.WorkerContext, j *borges.Job, err error) {
-	if err != nil {
-		log.Error("job errored", "WorkerID", ctx.ID, "RepositoryID", j.RepositoryID, "error", err)
-	} else {
-		log.Info("job done", "WorkerID", ctx.ID, "RepositoryID", j.RepositoryID)
-	}
-}
-
-func (c *consumerCmd) warnNotifier(ctx *borges.WorkerContext, j *borges.Job, err error) {
-	log.Warn("job warning", "WorkerID", ctx.ID, "RepositoryID", j.RepositoryID, "error", err)
-}
-
-func (c *consumerCmd) queueErrorNotifier(err error) {
-	log.Error("queue error", "error", err)
 }

--- a/cli/borges/producer.go
+++ b/cli/borges/producer.go
@@ -41,8 +41,7 @@ func (c *producerCmd) Execute(args []string) error {
 	}
 	defer ioutil.CheckClose(ji, &err)
 
-	p := borges.NewProducer(ji, q)
-	p.Notifiers.Done = c.notifier
+	p := borges.NewProducer(log, ji, q)
 	p.Start()
 
 	return err
@@ -66,13 +65,5 @@ func (c *producerCmd) jobIter(b queue.Broker) (borges.JobIter, error) {
 		return borges.NewLineJobIter(f, storer), nil
 	default:
 		return nil, fmt.Errorf("invalid source: %s", c.Source)
-	}
-}
-
-func (c *producerCmd) notifier(j *borges.Job, err error) {
-	if err != nil {
-		log.Error("job queue error", "RepositoryID", j.RepositoryID, "error", err)
-	} else {
-		log.Info("job queued", "RepositoryID", j.RepositoryID)
 	}
 }

--- a/common.go
+++ b/common.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/inconshreveable/log15"
 	"github.com/satori/go.uuid"
 	"gopkg.in/src-d/core-retrieval.v0"
 	"gopkg.in/src-d/core-retrieval.v0/model"
@@ -15,8 +14,6 @@ import (
 )
 
 var (
-	log = log15.New()
-
 	// ErrAlreadyStopped signals that an operation cannot be done because
 	// the entity is already sopped.
 	ErrAlreadyStopped = errors.NewKind("already stopped: %s")

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inconshreveable/log15"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,7 @@ type ConsumerSuite struct {
 }
 
 func (s *ConsumerSuite) newConsumer() *Consumer {
-	wp := NewWorkerPool(func(*WorkerContext, *Job) error { return nil })
+	wp := NewWorkerPool(log15.New(), func(log15.Logger, *Job) error { return nil })
 	return NewConsumer(s.queue, wp)
 }
 
@@ -37,7 +38,7 @@ func (s *ConsumerSuite) TestConsumer_StartStop_FailedJob() {
 
 	processed := 0
 	done := make(chan struct{}, 1)
-	c.WorkerPool.do = func(w *WorkerContext, j *Job) error {
+	c.WorkerPool.do = func(log log15.Logger, j *Job) error {
 		defer func() { done <- struct{}{} }()
 		processed++
 		if processed == 2 {
@@ -88,7 +89,7 @@ func (s *ConsumerSuite) TestConsumer_StartStop() {
 
 	processed := 0
 	done := make(chan struct{}, 1)
-	c.WorkerPool.do = func(*WorkerContext, *Job) error {
+	c.WorkerPool.do = func(log15.Logger, *Job) error {
 		processed++
 		if processed > 1 {
 			assert.Fail("too many jobs processed")

--- a/git.go
+++ b/git.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/inconshreveable/log15"
 	"gopkg.in/src-d/core-retrieval.v0/model"
 	"gopkg.in/src-d/go-billy.v3"
 	"gopkg.in/src-d/go-billy.v3/util"
@@ -123,7 +124,7 @@ func ResolveCommit(r *git.Repository, h plumbing.Hash) (*object.Commit, error) {
 	case *object.Tag:
 		return ResolveCommit(r, o.Target)
 	default:
-		log.Warn("referenced object not supported", "type", o.Type())
+		log15.Warn("referenced object not supported", "hash", h.String(), "type", o.Type())
 		return nil, ErrReferencedObjectTypeNotSupported
 	}
 }


### PR DESCRIPTION
* Remove notifiers: we did use them only for logging, and we did
  not remove logger usage with them anyway.
* Propagate logger instances (no global logger) and defined context.
  This improves log message by ensuring proper context fields are
  not missing.