### PR TITLE
added refspec to fetch HEAD as refs/heads/HEAD

### DIFF
--- a/git.go
+++ b/git.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	FetchRefSpec = config.RefSpec("refs/*:refs/*")
+	FetchHEAD    = config.RefSpec("HEAD:refs/heads/HEAD")
 )
 
 type TemporaryRepository interface {
@@ -171,7 +172,7 @@ func (b *temporaryRepositoryBuilder) Clone(id, endpoint string) (TemporaryReposi
 	}
 
 	o := &git.FetchOptions{
-		RefSpecs: []config.RefSpec{FetchRefSpec},
+		RefSpecs: []config.RefSpec{FetchRefSpec, FetchHEAD},
 	}
 	err = remote.Fetch(o)
 	if err == git.NoErrAlreadyUpToDate || err == transport.ErrEmptyRemoteRepository {

--- a/git_test.go
+++ b/git_test.go
@@ -106,7 +106,8 @@ func (s *TemporaryClonerSuite) testBasicRepository(url string) {
 	require.NoError(err)
 	refs, err := gr.References()
 	require.NoError(err)
-	require.Len(refs, 3)
+	// len(refs) = FetchRefSpec + FetchHEAD = x + 1
+	require.Len(refs, 4)
 	err = gr.Close()
 	require.NoError(err)
 }


### PR DESCRIPTION
Now remote HEAD is fetched through  the refspec "HEAD:refs/heads/HEAD" for each repository.

```bash
➜  /tmp siva list root-repositories/d668b7841482f156c60b03cfbc93a0fdcebe1d66.siva 
-rw-rw-rw- Jul 26 14:03   23 B HEAD
-rw-rw-rw- Jul 26 14:03   20 B config
-rw-rw-rw- Jul 26 14:04  93 kB objects/pack/pack-1ae420565b6543769da850583c076476e5c1dad9.idx
-rw-rw-rw- Jul 26 14:04 710 kB objects/pack/pack-1ae420565b6543769da850583c076476e5c1dad9.pack
-rw-rw-rw- Jul 26 14:04   41 B refs/heads/HEAD/015d7ec8-05f4-d5da-aace-d7e26afa0fa0
-rw-rw-rw- Jul 26 14:04   41 B refs/heads/feature/rpm/015d7ec8-05f4-d5da-aace-d7e26afa0fa0
-rw-rw-rw- Jul 26 14:04   41 B refs/heads/master/015d7ec8-05f4-d5da-aace-d7e26afa0fa0
-rw-rw-rw- Jul 26 14:04   41 B refs/pull/1/head/015d7ec8-05f4-d5da-aace-d7e26afa0fa0
-rw-rw-rw- Jul 26 14:04   41 B refs/tags/v3.0.1/015d7ec8-05f4-d5da-aace-d7e26afa0fa0
-rw-rw-rw- Jul 26 14:04   41 B refs/tags/v3.0.2/015d7ec8-05f4-d5da-aace-d7e26afa0fa0

➜  /tmp cat d668b78/refs/heads/HEAD/015d7ec8-05f4-d5da-aace-d7e26afa0fa0 
851c0b9bbf4ebe54b8f835dfb7a5935f9f7b3ddd
```
