### PR TITLE
common: Update aliases if needed

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -2,17 +2,25 @@ package borges
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/src-d/core-retrieval.v0/model"
+	"gopkg.in/src-d/core-retrieval.v0/test"
 	"gopkg.in/src-d/framework.v0/queue"
+	"gopkg.in/src-d/go-kallax.v1"
 )
 
 const (
 	testBrokerURI   = "amqp://localhost:5672"
 	testQueuePrefix = "borges_test_queue"
 )
+
+func TestCommon(t *testing.T) {
+	suite.Run(t, new(RepositoryIDSuite))
+}
 
 type BaseQueueSuite struct {
 	suite.Suite
@@ -31,15 +39,105 @@ func (s *BaseQueueSuite) SetupTest() {
 }
 
 func (s *BaseQueueSuite) TearDownTest() {
-	assert := assert.New(s.T())
-	assert.NoError(s.broker.Close())
+	s.NoError(s.broker.Close())
 }
 
 func (s *BaseQueueSuite) connectQueue() {
-	assert := assert.New(s.T())
 	var err error
 	s.broker, err = queue.NewBroker(testBrokerURI)
-	assert.NoError(err)
+	s.NoError(err)
 	s.queue, err = s.broker.Queue(s.queueName)
-	assert.NoError(err)
+	s.NoError(err)
+}
+
+type RepositoryIDSuite struct {
+	test.Suite
+
+	storer *model.RepositoryStore
+
+	isTrue  bool
+	isFalse bool
+}
+
+func (s *RepositoryIDSuite) TestRepositoryIDSameUrls() {
+	id1, err := RepositoryID([]string{"a", "b"}, nil, s.storer)
+	s.NoError(err)
+
+	id2, err := RepositoryID([]string{"a", "b"}, nil, s.storer)
+	s.NoError(err)
+
+	s.Equal(id1, id2)
+
+}
+
+func (s *RepositoryIDSuite) TestRepositoryIDOtherUrls() {
+	id1, err := RepositoryID([]string{"a", "c"}, nil, s.storer)
+	s.NoError(err)
+
+	id2, err := RepositoryID([]string{"a", "b"}, nil, s.storer)
+	s.NoError(err)
+
+	s.Equal(id1, id2)
+	a := s.getRepository(id1).Endpoints
+	s.Contains(a, "a")
+	s.Contains(a, "b")
+	s.Contains(a, "c")
+
+	s.Equal(3, len(a))
+}
+
+func (s *RepositoryIDSuite) TestRepositoryIDMoreUrlsSecondStep() {
+	id1, err := RepositoryID([]string{"a"}, nil, s.storer)
+	s.NoError(err)
+
+	id2, err := RepositoryID([]string{"a", "b", "c"}, nil, s.storer)
+	s.NoError(err)
+
+	s.Equal(id1, id2)
+	a := s.getRepository(id1).Endpoints
+	s.Contains(a, "a")
+	s.Contains(a, "b")
+	s.Contains(a, "c")
+
+	s.Equal(3, len(a))
+}
+
+func (s *RepositoryIDSuite) TestRepositoryIDNotEqualID() {
+	id1, err := RepositoryID([]string{"a"}, nil, s.storer)
+	s.NoError(err)
+
+	id2, err := RepositoryID([]string{"b", "c"}, nil, s.storer)
+	s.NoError(err)
+
+	s.NotEqual(id1, id2)
+	a := s.getRepository(id1).Endpoints
+	s.Contains(a, "a")
+	s.Equal(1, len(a))
+
+	b := s.getRepository(id2).Endpoints
+	s.Contains(b, "b")
+	s.Contains(b, "c")
+	s.Equal(2, len(b))
+}
+
+func (s *RepositoryIDSuite) getRepository(id uuid.UUID) *model.Repository {
+	rs, err := s.storer.Find(model.NewRepositoryQuery().FindByID(kallax.ULID(id)))
+	s.NoError(err)
+	r, err := rs.One()
+	s.NoError(err)
+
+	return r
+}
+
+func (s *RepositoryIDSuite) SetupTest() {
+	s.Setup()
+
+	s.storer = model.NewRepositoryStore(s.DB)
+
+	s.isTrue = true
+	s.isFalse = false
+}
+
+func (s *RepositoryIDSuite) TearDownTest() {
+	s.TearDown()
 }


### PR DESCRIPTION
If searching for the repositoryID by repository urls our mention has new aliases, we should add them to the existing repository.