### PR TITLE
fix broken tests

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -108,7 +108,7 @@ func (s *TemporaryClonerSuite) testBasicRepository(url string) {
 	refs, err := gr.References()
 	require.NoError(err)
 	// len(refs) = FetchRefSpec + FetchHEAD = x + 1
-	require.Len(refs, 4)
+	require.Len(refs, 6)
 	err = gr.Close()
 	require.NoError(err)
 }


### PR DESCRIPTION
A new PR in the basic git fixture broke tests assumptions
about references in that repository. See:

https://github.com/git-fixtures/basic/pull/2