### PR TITLE
test: ensure temporary database is used

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -23,7 +23,7 @@ func TestCommon(t *testing.T) {
 }
 
 type BaseQueueSuite struct {
-	suite.Suite
+	test.Suite
 	broker    queue.Broker
 	queue     queue.Queue
 	queueName string
@@ -36,10 +36,12 @@ func (s *BaseQueueSuite) SetupSuite() {
 
 func (s *BaseQueueSuite) SetupTest() {
 	s.connectQueue()
+	s.Suite.Setup()
 }
 
 func (s *BaseQueueSuite) TearDownTest() {
 	s.NoError(s.broker.Close())
+	s.Suite.TearDown()
 }
 
 func (s *BaseQueueSuite) connectQueue() {

--- a/producer_test.go
+++ b/producer_test.go
@@ -9,8 +9,7 @@ import (
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/src-d/core-retrieval.v0"
-	rmodel "gopkg.in/src-d/core-retrieval.v0/model"
+	"gopkg.in/src-d/core-retrieval.v0/model"
 	"gopkg.in/src-d/framework.v0/queue"
 )
 
@@ -36,18 +35,14 @@ func (s *ProducerSuite) SetupSuite() {
 }
 
 func (s *ProducerSuite) newProducer() *Producer {
-	DropTables("repository")
-	DropIndexes("idx_endpoints")
-	CreateRepositoryTable()
-	storer := core.ModelRepositoryStore()
-
+	storer := model.NewRepositoryStore(s.DB)
 	return NewProducer(NewMentionJobIter(s.mentionsQueue, storer), s.queue)
 }
 
 func (s *ProducerSuite) newJob() *queue.Job {
 	j := queue.NewJob()
-	m := &rmodel.Mention{
-		VCS:      rmodel.GIT,
+	m := &model.Mention{
+		VCS:      model.GIT,
 		Provider: "TEST_PROVIDER",
 		Endpoint: testEndpoint,
 	}


### PR DESCRIPTION
ProducerSuite was still using a global database instead of a temporary
one.