### PR TITLE
set repositories as fetching until they're fully fetched

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f7facdfee599c5deed9a512c14904c8e905762e38f00cecfb3993ec7a3b660f5
-updated: 2017-08-02T10:27:27.797926797+02:00
+hash: 494e7800fcb2650325dad2a984d37da778d8535cf72eb71923cf403bcd6062c0
+updated: 2017-08-08T18:24:26.559640091+02:00
 imports:
 - name: github.com/colinmarc/hdfs
   version: d9614569203878ff04bb4420b929923949e855fc
@@ -152,7 +152,7 @@ imports:
   - stack
   - term
 - name: gopkg.in/src-d/core-retrieval.v0
-  version: 066728d73336d0685822ab5549e3cd106a85ab4d
+  version: 86edcacd5511381170a836d5ddd0ae062d075e46
   subpackages:
   - model
   - repository

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,9 +25,9 @@ import:
   - storage/filesystem
   - utils/ioutil
 - package: gopkg.in/src-d/go-kallax.v1
-  version: ^1.2.7
+  version: 1.2.x
 - package: gopkg.in/src-d/core-retrieval.v0
-  version: 066728d73336d0685822ab5549e3cd106a85ab4d
+  version: 86edcacd5511381170a836d5ddd0ae062d075e46
   subpackages:
   - model
   - repository


### PR DESCRIPTION
Closes #112 

This PR introduces a mechanism to ensure fatal errors do not lead to repositories being incorrectly reprocessed. To do this, when a consumer worker receives a job, it checks if the repository has the `fetching` status. If it does, it means there was a fatal error when it started processing and returns an error, which leads to the job being rejected and it's thus sent to the dead letter queue.
Immediately after that, the worker sets the status of the repository to `fetching` if it's any other status and continues normally until the end, when the status is changed to `not_found`, `fetched` or `pending` depending on the circumstances at the end of the process.

So, after the job is process (or not, if it crashes) this are the possible statuses of a repository:

* Process crashed: `fetching`
* Repo not found:  `not_found`
* All ok: `fetched` 
* Any other error: `pending` and `FetchErrorAt` is updated