### PR TITLE
create init command to initialize database

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,24 +50,12 @@ they will just retry until it does.
 - `make dependencies` to download vendor dependencies using Glide.
 - `make packages` to generate binaries for several platforms.
 
-You will find binaries in `borges_linux_amd64/borges` and `borges_darwin_amd64/borges`. 
+You will find binaries in `borges_linux_amd64/borges` and `borges_darwin_amd64/borges`.
 
-If running for the first time, you also need to add the following table to PostgreSQL:
+If you're running borges for the first time, make sure you initialize the schema of the database first. You can do so by running the following command:
 
-```sql
-CREATE TABLE IF NOT EXISTS repositories (
-    id uuid PRIMARY KEY,
-    created_at timestamptz,
-    updated_at timestamptz,
-    endpoints text[],
-    status varchar(20),
-    fetched_at timestamptz,
-    fetch_error_at timestamptz,
-    last_commit_at timestamptz,
-    _references jsonb
-);
-    
-CREATE INDEX idx_endpoints on "repositories" USING GIN ("endpoints");
+```
+borges init
 ```
 
 ## Test

--- a/cli/borges/init.go
+++ b/cli/borges/init.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/inconshreveable/log15"
+
+	"gopkg.in/src-d/core-retrieval.v0/schema"
+	"gopkg.in/src-d/framework.v0/database"
+)
+
+const (
+	initCmdName      = "init"
+	initCmdShortDesc = "initialize the database schema"
+	initCmdLongDesc  = ""
+)
+
+type initCmd struct {
+	loggerCmd
+}
+
+func (c *initCmd) Execute(args []string) error {
+	c.ChangeLogLevel()
+
+	db, err := database.Default()
+	if err != nil {
+		return fmt.Errorf("unable to get database: %s", err)
+	}
+
+	if err := schema.Create(db); err != nil {
+		return fmt.Errorf("unable to create database schema: %s", err)
+	}
+
+	log15.Info("database was successfully initialized")
+	return nil
+}

--- a/cli/borges/main.go
+++ b/cli/borges/main.go
@@ -21,15 +21,19 @@ var (
 	log     log15.Logger
 )
 
+type loggerCmd struct {
+	LogLevel string `short:"" long:"loglevel" description:"max log level enabled" default:"info"`
+	LogFile  string `short:"" long:"logfile" description:"path to file where logs will be stored" default:""`
+}
+
 type cmd struct {
+	loggerCmd
 	Queue        string `long:"queue" default:"borges" description:"queue name"`
-	LogLevel     string `short:"" long:"loglevel" description:"max log level enabled" default:"info"`
-	LogFile      string `short:"" long:"logfile" description:"path to file where logs will be stored" default:""`
 	Profiler     bool   `long:"profiler" description:"start CPU, memory and block profilers"`
 	ProfilerPort int    `long:"profiler-port" description:"port to bind profiler to" default:"6061"`
 }
 
-func (c *cmd) ChangeLogLevel() {
+func (c *loggerCmd) ChangeLogLevel() {
 	lvl, err := log15.LvlFromString(c.LogLevel)
 	if err != nil {
 		panic(fmt.Sprintf("unknown level name %q", c.LogLevel))
@@ -76,6 +80,10 @@ func main() {
 
 	if _, err := parser.AddCommand(producerCmdName, producerCmdShortDesc,
 		producerCmdLongDesc, &producerCmd{}); err != nil {
+		panic(err)
+	}
+
+	if _, err := parser.AddCommand(initCmdName, initCmdShortDesc, initCmdLongDesc, new(initCmd)); err != nil {
 		panic(err)
 	}
 

--- a/common.go
+++ b/common.go
@@ -2,12 +2,9 @@ package borges
 
 import (
 	stderrors "errors"
-	"fmt"
 	"io"
-	"strings"
 
 	"github.com/satori/go.uuid"
-	"gopkg.in/src-d/core-retrieval.v0"
 	"gopkg.in/src-d/core-retrieval.v0/model"
 	"gopkg.in/src-d/go-errors.v0"
 	"gopkg.in/src-d/go-kallax.v1"
@@ -120,43 +117,6 @@ func getUniqueEndpoints(re, ne []string) ([]string, bool) {
 	}
 
 	return result, true
-}
-
-// TODO temporal
-func DropTables(names ...string) {
-	smt := fmt.Sprintf("DROP TABLE IF EXISTS %s;", strings.Join(names, ", "))
-	if _, err := core.Database().Exec(smt); err != nil {
-		panic(err)
-	}
-}
-
-// TODO temporal
-func DropIndexes(names ...string) {
-	smt := fmt.Sprintf("DROP INDEX IF EXISTS %s;", strings.Join(names, ", "))
-	if _, err := core.Database().Exec(smt); err != nil {
-		panic(err)
-	}
-}
-
-// TODO temporal delete when kallax implements it
-func CreateRepositoryTable() {
-	_, err := core.Database().Exec(`CREATE TABLE IF NOT EXISTS repositories (
-	id uuid PRIMARY KEY,
-	created_at timestamptz,
-	updated_at timestamptz,
-	endpoints text[],
-	status varchar(20),
-	fetched_at timestamptz,
-	fetch_error_at timestamptz,
-	last_commit_at timestamptz,
-	is_fork boolean,
-	_references jsonb
-	);
-	CREATE INDEX idx_endpoints on "repositories" USING GIN ("endpoints");`)
-
-	if err != nil {
-		panic(err)
-	}
 }
 
 // Referencer can retrieve reference models (*model.Reference).

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 494e7800fcb2650325dad2a984d37da778d8535cf72eb71923cf403bcd6062c0
-updated: 2017-08-08T18:24:26.559640091+02:00
+hash: 9932a10757f2ad8e10b9002ab0cc0ee7c90dcb4d31c73015e4dc32f72fe0616d
+updated: 2017-08-09T17:43:03.142733435+02:00
 imports:
 - name: github.com/colinmarc/hdfs
   version: d9614569203878ff04bb4420b929923949e855fc
@@ -42,9 +42,9 @@ imports:
   subpackages:
   - oid
 - name: github.com/Masterminds/squirrel
-  version: 20f192218cf52a73397fa2df45bdda720f3e47c8
+  version: 3c07e090bf7ba1ae79ff08462c323e25196e164b
 - name: github.com/mattn/go-colorable
-  version: 3fa8c76f9daed4067e4a806fb7e4dc86455c6d6a
+  version: 6c0fd4aa6ec5818d5e3ea9e03ae436972a6c5a9a
 - name: github.com/mattn/go-isatty
   version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mcuadros/go-defaults
@@ -76,7 +76,7 @@ imports:
 - name: github.com/streadway/amqp
   version: 2cbfe40c9341ad63ba23e53013b3ddc7989d801c
 - name: github.com/stretchr/testify
-  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
+  version: 05e8a0eda380579888eb53c394909df027f06991
   subpackages:
   - assert
   - require
@@ -107,14 +107,14 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: cfdf022e86b4ecfb646e1efbd7db175dd623a8fa
+  version: 3bd178b88a8180be2df394a1fbb81313916f0e7b
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/appengine
-  version: ad2570cd3913654e00c5f0183b39d2f998e54046
+  version: c5a90ac045b779001847fec87403f5cba090deae
   subpackages:
   - datastore
   - internal
@@ -125,7 +125,7 @@ imports:
   - internal/modules
   - internal/remote_api
 - name: google.golang.org/genproto
-  version: b0a3dcfcd1a9bd48e63634bd8802960804cf8315
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -152,10 +152,11 @@ imports:
   - stack
   - term
 - name: gopkg.in/src-d/core-retrieval.v0
-  version: 86edcacd5511381170a836d5ddd0ae062d075e46
+  version: 6a67746f6ec820392eb0b8253d8150717f14d8ee
   subpackages:
   - model
   - repository
+  - schema
   - test
 - name: gopkg.in/src-d/framework.v0
   version: b7e5e412473a20a56c0543f898624f024b164087
@@ -222,11 +223,11 @@ imports:
   - utils/merkletrie/internal/frame
   - utils/merkletrie/noder
 - name: gopkg.in/src-d/go-kallax.v1
-  version: 398b52f91a8aabf0fef63234fc5367bce55002e4
+  version: 80487620b6c62eb3f558bf9863be31842912dd47
   subpackages:
   - types
 - name: gopkg.in/src-d/go-siva.v1
-  version: df707095626f384ce2dc1a83b30f9a21d69b9dfc
+  version: 1b9a917e872d49accbc4f4283b4fc0beb40e91b8
 - name: gopkg.in/vmihailenco/msgpack.v2
   version: f4f8982de4ef0de18be76456617cc3f5d8d8141e
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,9 +25,9 @@ import:
   - storage/filesystem
   - utils/ioutil
 - package: gopkg.in/src-d/go-kallax.v1
-  version: 1.2.x
+  version: ^1.3.1
 - package: gopkg.in/src-d/core-retrieval.v0
-  version: 86edcacd5511381170a836d5ddd0ae062d075e46
+  version: 6a67746f6ec820392eb0b8253d8150717f14d8ee
   subpackages:
   - model
   - repository


### PR DESCRIPTION
Fixes #21 

### Changes

- Added `init` command that uses `schema.Create` of core-retrieval
- Split `cmd` in two, `loggerCmd` and `cmd` which embeds `loggerCmd`. The rationale behind that is that all commands need to embed `loggerCmd` to control the log in the same way, but not all need to embed `cmd`, such as `init`. Doing so would mean `init` would have, for example, a `queue` flag that is not needed.
