### PR TITLE
ensure repository status is correctly set in all cases

### DIFF
--- a/archiver_test.go
+++ b/archiver_test.go
@@ -210,6 +210,19 @@ func (s *ArchiverSuite) TestProcessingRepository() {
 	s.Equal(model.Fetching, mr.Status)
 }
 
+func (s *ArchiverSuite) TestDbUpdateRepositoryStatus() {
+	rid := s.newRepositoryModel("git://foo.bar.qux")
+	repo, err := s.store.FindOne(model.NewRepositoryQuery().FindByID(rid))
+	s.NoError(err)
+
+	s.NoError(s.a.dbUpdateRepositoryStatus(repo, model.Fetching))
+
+	mr, err := s.store.FindOne(model.NewRepositoryQuery().FindByID(rid))
+	s.NoError(err)
+
+	s.Equal(model.Fetching, mr.Status)
+}
+
 func (s *ArchiverSuite) newRepositoryModel(endpoint string) kallax.ULID {
 	mr := model.NewRepository()
 	mr.Endpoints = append(mr.Endpoints, endpoint)


### PR DESCRIPTION
Depends on #147 

We should create an issue as well to remember that we should rethink and refactor `do` of `Archiver` so it's more easy to follow. Right now, there are a lot of cases where it could go wrong and we have to be very careful to change the status at the end. (One possible solution would be a defer and setting as pending if it's not not_found or fetched).