### PR TITLE
gitReferencer: cache roots of visited commits

### DIFF
--- a/changes_test.go
+++ b/changes_test.go
@@ -26,6 +26,19 @@ func TestNewChanges(t *testing.T) {
 	}
 }
 
+func BenchmarkNewChanges(b *testing.B) {
+	for _, ct := range ChangesFixtures {
+		b.Run(ct.TestName, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				oldRefs := NewModelReferencer(&model.Repository{References: ct.OldReferences})
+				newRefs := NewModelReferencer(&model.Repository{References: ct.NewReferences})
+				_, err := newChanges(timeNow, oldRefs, newRefs)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
 func sortChanges(c Changes) {
 	for _, cmds := range c {
 		sort.Sort(cmdSort(cmds))


### PR DESCRIPTION
The roots of all the visited commits are cached so when we're
looking for the roots of other references, they don't have to be
visited yet again.
This slows down a bit the lookup for references that have commits
not yet visited, but makes the rest super fast.
A benchmark for NewChanges has been added that shows the mentioned
slowdown (which is not that big), but real usage outside tests
shows that operations that took almost ~2m now take ~1s.