### PR TITLE
Change PID1 in Borges container to dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.6
 MAINTAINER source{d}
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates dumb-init=1.2.0-r0
 
 ADD build/borges_linux_amd64/borges /bin/
 
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["borges"]


### PR DESCRIPTION
Adding [low-overhead PID1](https://github.com/Yelp/dumb-init) instead of borges process increases ability of debugging the system.

I.e in case borges consumer process hangs - it would be possible to `kill -ABRT <borges-PID>` (which will be not 1) inside the container and get a stack dump of stalled goroutines.