### PR TITLE
gitReferencer: make sure no branches are skipped finding root commits

### DIFF
--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -279,6 +279,8 @@ func testUpdateCommand(old, new *model.Reference) *Command {
 	}
 }
 
+const multipleRootsFixture = 9
+
 var ChangesFixtures = []*ChangesFixture{{
 	TestName:      "no previous references and no updates",
 	OldReferences: nil,
@@ -462,7 +464,7 @@ var ChangesFixtures = []*ChangesFixture{{
 			testAddCommand(fixtureReferences.ByName("refs/heads/rootReference")),
 		},
 	},
-}, {
+}, { // multipleRootsFixture
 	TestName: "all reference are new except one (updated with new init)",
 	OldReferences: []*model.Reference{
 		withRoots(

--- a/git.go
+++ b/git.go
@@ -93,19 +93,51 @@ func (r gitReferencer) References() ([]*model.Reference, error) {
 type commitFrame struct {
 	cursor int
 	hashes []plumbing.Hash
-	roots  [][]model.SHA1
 }
 
+func newCommitFrame(hashes ...plumbing.Hash) *commitFrame {
+	return &commitFrame{0, hashes}
+}
+
+// lastHash returns the last visited hash, assuming one has at least been
+// visited before. That is, this should not be called before incrementing
+// the cursor for the first time.
+func (f *commitFrame) lastHash() plumbing.Hash {
+	return f.hashes[f.cursor-1]
+}
+
+// rootCommits returns the commits with no parents reachable from `start`.
+// To do so, all the commits are iterated using a stack where frames are
+// the parent commits of the last visited hash of the previous frame.
+//
+// As we go down, if a commit has parents, we add a new frame to the stack
+// with these parents as hashes.
+// If the commit does not have parents its a root, so we add it to the list
+// found roots and keep going.
+//
+// If we have not visited all the hashes in the current frame it means we have
+// to switch branches. That means caching the roots found so far for the last
+// visited commit in the frame and reset the roots so we can find the ones
+// for the new root. If these branches converge nothing happens, that
+// point will be cached and we'll load them from the cache and continue.
+// If we have visited all the hashes in the current frame we cache the found
+// roots and move all the roots found in all the hashes in the frame to the
+// last visited hash of the previous frame. The found roots now will be the
+// same roots we pushed to the previous frame.
+//
+// After repeating this process, when we get to the root frame, we just have to
+// return the roots cached for it, which will be the roots of all reachable
+// commits from the start.
 func rootCommits(
 	r *git.Repository,
 	start *object.Commit,
 	seenRoots map[plumbing.Hash][]model.SHA1,
 ) ([]model.SHA1, error) {
-	var seen = make(map[plumbing.Hash]bool)
 	stack := []*commitFrame{
-		&commitFrame{0, []plumbing.Hash{start.Hash}, make([][]model.SHA1, 1)},
+		newCommitFrame(start.Hash),
 	}
 	store := r.Storer
+	var roots []model.SHA1
 
 	for {
 		current := len(stack) - 1
@@ -115,39 +147,43 @@ func rootCommits(
 
 		frame := stack[current]
 		if len(frame.hashes) <= frame.cursor {
+			roots = deduplicateHashes(roots)
+			seenRoots[frame.lastHash()] = roots
+
+			// root frame is guaranteed to have just one hash
 			if current == 0 {
-				seenRoots[frame.hashes[0]] = frame.roots[0]
-				return deduplicateHashes(frame.roots[0]), nil
+				return seenRoots[frame.lastHash()], nil
 			}
 
-			if current > 0 {
-				prevFrame := stack[current-1]
-				for i, r := range frame.roots {
-					prevFrame.roots[prevFrame.cursor-1] = append(prevFrame.roots[prevFrame.cursor-1], r...)
-					if _, ok := seenRoots[frame.hashes[i]]; !ok {
-						seenRoots[frame.hashes[i]] = r
-					}
-				}
+			// move all the roots of all the branches to the last visited
+			// hash of the previous frame
+			prevFrame := stack[current-1]
+
+			prevHash := prevFrame.lastHash()
+			for _, h := range frame.hashes {
+				seenRoots[prevHash] = append(seenRoots[prevHash], seenRoots[h]...)
 			}
+
+			roots = deduplicateHashes(seenRoots[prevHash])
+			seenRoots[prevHash] = roots
 
 			stack = stack[:current]
 			continue
-		}
-
-		hash := frame.hashes[frame.cursor]
-		if roots, ok := seenRoots[hash]; ok {
-			frame.roots[frame.cursor] = roots
-			frame.cursor++
-			continue
+		} else if frame.cursor > 0 {
+			// if the frame cursor is bigger than 0 and we're not done with it
+			// cache the roots of the previous hash and start anew with the
+			// next branch.
+			seenRoots[frame.lastHash()] = deduplicateHashes(roots)
+			roots = nil
 		}
 
 		frame.cursor++
-
-		if seen[hash] {
+		hash := frame.lastHash()
+		// use cached roots for this commit, if any
+		if cachedRoots, ok := seenRoots[hash]; ok {
+			roots = cachedRoots
 			continue
 		}
-
-		seen[hash] = true
 
 		var c *object.Commit
 		if hash != start.Hash {
@@ -167,13 +203,9 @@ func rootCommits(
 		}
 
 		if c.NumParents() > 0 {
-			stack = append(stack, &commitFrame{
-				0,
-				c.ParentHashes,
-				make([][]model.SHA1, len(c.ParentHashes)),
-			})
+			stack = append(stack, newCommitFrame(c.ParentHashes...))
 		} else {
-			frame.roots[frame.cursor-1] = append(frame.roots[frame.cursor-1], model.SHA1(c.Hash))
+			roots = append(roots, model.SHA1(c.Hash))
 		}
 	}
 }


### PR DESCRIPTION
This fixes the problem introduce by the performance improvement in gitReferencer. While I initially only fixed it, after trying it with `rails/rails` it still took 2 hours to do this. This is because if we use the preorder iterator that comes from go-git, we can't skip branches as easily. 

Imagine we have two branches, one with a root commit and another one with 50M commits. Because the branch with the root commit has not been visited yet we can't break the iteration and we have to continue all the way until we get to it. What's the problem? That means we'll iterate over these 50M commits (and decode them) just to get to one commit.

This is why I have ditched completely the iterator from go-git and made a custom iterator implementation based on it that retrieves root commits. Since we have now all the control over it, we can make it much more efficient. In the case mentioned before, on the first commit of the already visited branch we'd use the cached roots of that branch and skip it, instead of iterating over all the commits again.
The implementation has a downside, though: it's using go-git in a very low-level way (manually decoding objects and iterating) so it may break in the future. But it's the only thing we can do if we truly want performance here.

### So, how does this work?

Like the preorder iterator, it has a stack with frames. Each frame has hashes, which are always children of the commit with the hash at cursor - 1 in the previous frame. Each frame has also a cursor, to know in which branch of the frame we are and a slice of roots for every hash.
Every time we visit a new commit, we add a new frame with its parents and the next iteration we'll continue with them. So we go all the way down and then we start going all the way up until we find a new branch we need to visit.
When we are done with a frame, we push the roots up to its corresponding parent all the way up until we are at the root frame (guaranteed to have only one hash) and roots are returned.

Since roots can be duplicated (for performance reason roots are cached) by design, we deduplicate them on return. The list of roots is usually really small, so deduplicate it is trivial and does not really have a performance impact.

### Some numbers

Getting the roots of `rails/rails` used to take 2.5h (even after the optimization), now it takes ~13s.
I don't know how much it took with git before, but now it takes ~12s.