### PR TITLE
implement RepoStore abstraction for the repo storage layer

### DIFF
--- a/cli/borges/consumer.go
+++ b/cli/borges/consumer.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/src-d/borges"
+	"github.com/src-d/borges/storage"
 
 	"gopkg.in/src-d/core-retrieval.v0"
 )
@@ -38,7 +39,7 @@ func (c *consumerCmd) Execute(args []string) error {
 
 	wp := borges.NewArchiverWorkerPool(
 		log,
-		core.ModelRepositoryStore(),
+		storage.FromDatabase(core.Database()),
 		core.RootedTransactioner(),
 		borges.NewTemporaryCloner(core.TemporaryFilesystem()),
 		core.Locking(),

--- a/cli/borges/producer.go
+++ b/cli/borges/producer.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/src-d/borges"
+	"github.com/src-d/borges/storage"
 
 	"gopkg.in/src-d/core-retrieval.v0"
 	"gopkg.in/src-d/framework.v0/queue"
@@ -49,7 +50,7 @@ func (c *producerCmd) Execute(args []string) error {
 }
 
 func (c *producerCmd) jobIter(b queue.Broker) (borges.JobIter, error) {
-	storer := core.ModelRepositoryStore()
+	storer := storage.FromDatabase(core.Database())
 
 	switch c.Source {
 	case "mentions":

--- a/common_test.go
+++ b/common_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/satori/go.uuid"
+	"github.com/src-d/borges/storage"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/src-d/core-retrieval.v0/model"
 	"gopkg.in/src-d/core-retrieval.v0/test"
@@ -55,7 +56,7 @@ func (s *BaseQueueSuite) connectQueue() {
 type RepositoryIDSuite struct {
 	test.Suite
 
-	storer *model.RepositoryStore
+	storer storage.RepoStore
 
 	isTrue  bool
 	isFalse bool
@@ -123,18 +124,15 @@ func (s *RepositoryIDSuite) TestRepositoryIDNotEqualID() {
 }
 
 func (s *RepositoryIDSuite) getRepository(id uuid.UUID) *model.Repository {
-	rs, err := s.storer.Find(model.NewRepositoryQuery().FindByID(kallax.ULID(id)))
+	repo, err := s.storer.Get(kallax.ULID(id))
 	s.NoError(err)
-	r, err := rs.One()
-	s.NoError(err)
-
-	return r
+	return repo
 }
 
 func (s *RepositoryIDSuite) SetupTest() {
 	s.Setup()
 
-	s.storer = model.NewRepositoryStore(s.DB)
+	s.storer = storage.FromDatabase(s.DB)
 
 	s.isTrue = true
 	s.isFalse = false

--- a/linejobiter.go
+++ b/linejobiter.go
@@ -6,18 +6,18 @@ import (
 	"io"
 	"net/url"
 
-	"gopkg.in/src-d/core-retrieval.v0/model"
+	"github.com/src-d/borges/storage"
 )
 
 type lineJobIter struct {
-	storer *model.RepositoryStore
+	storer storage.RepoStore
 	*bufio.Scanner
 	r io.ReadCloser
 }
 
 // NewLineJobIter returns a JobIter that returns jobs generated from a reader
 // with a list of repository URLs, one per line.
-func NewLineJobIter(r io.ReadCloser, storer *model.RepositoryStore) JobIter {
+func NewLineJobIter(r io.ReadCloser, storer storage.RepoStore) JobIter {
 	return &lineJobIter{
 		storer:  storer,
 		Scanner: bufio.NewScanner(r),

--- a/mentionjobiter.go
+++ b/mentionjobiter.go
@@ -1,20 +1,20 @@
 package borges
 
 import (
-	"gopkg.in/src-d/core-retrieval.v0/model"
+	"github.com/src-d/borges/storage"
 	rmodel "gopkg.in/src-d/core-retrieval.v0/model"
 	"gopkg.in/src-d/framework.v0/queue"
 )
 
 type mentionJobIter struct {
-	storer *model.RepositoryStore
+	storer storage.RepoStore
 	q      queue.Queue
 	iter   queue.JobIter
 }
 
 // NewMentionJobIter returns a JobIter that returns jobs generated from
 // mentions received from a queue (e.g. from rovers).
-func NewMentionJobIter(q queue.Queue, storer *model.RepositoryStore) JobIter {
+func NewMentionJobIter(q queue.Queue, storer storage.RepoStore) JobIter {
 	return &mentionJobIter{
 		storer: storer,
 		q:      q,

--- a/producer_test.go
+++ b/producer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/satori/go.uuid"
+	"github.com/src-d/borges/storage"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/src-d/core-retrieval.v0/model"
@@ -36,7 +37,7 @@ func (s *ProducerSuite) SetupSuite() {
 }
 
 func (s *ProducerSuite) newProducer() *Producer {
-	storer := model.NewRepositoryStore(s.DB)
+	storer := storage.FromDatabase(s.DB)
 	return NewProducer(log15.New(), NewMentionJobIter(s.mentionsQueue, storer), s.queue)
 }
 

--- a/storage/database.go
+++ b/storage/database.go
@@ -1,0 +1,111 @@
+package storage
+
+import (
+	"database/sql"
+	"time"
+
+	"gopkg.in/src-d/core-retrieval.v0/model"
+	kallax "gopkg.in/src-d/go-kallax.v1"
+)
+
+type dbRepoStore struct {
+	*model.RepositoryStore
+}
+
+// FromDatabase returns a new repository store that interacts with a PostgreSQL
+// FromDatabase to store all the data.
+func FromDatabase(db *sql.DB) RepoStore {
+	return &dbRepoStore{model.NewRepositoryStore(db)}
+}
+
+func (s *dbRepoStore) Create(repo *model.Repository) error {
+	_, err := s.Save(repo)
+	return err
+}
+
+func (s *dbRepoStore) Get(id kallax.ULID) (*model.Repository, error) {
+	q := model.NewRepositoryQuery().FindByID(id)
+	return s.FindOne(q)
+}
+
+func (s *dbRepoStore) GetByEndpoints(endpoints ...string) ([]*model.Repository, error) {
+	q := make([]interface{}, len(endpoints))
+	for _, ep := range endpoints {
+		q = append(q, ep)
+	}
+
+	rs, err := s.Find(
+		model.NewRepositoryQuery().
+			Where(kallax.And(kallax.ArrayOverlap(
+				model.Schema.Repository.Endpoints, q...,
+			))),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	repositories, err := rs.All()
+	if err != nil {
+		return nil, err
+	}
+
+	return repositories, nil
+}
+
+func (s *dbRepoStore) SetStatus(repo *model.Repository, status model.FetchStatus) error {
+	repo.Status = status
+	_, err := s.RepositoryStore.Update(
+		repo,
+		model.Schema.Repository.Status,
+	)
+	return err
+}
+
+func (s *dbRepoStore) SetEndpoints(repo *model.Repository, endpoints ...string) error {
+	repo.Endpoints = endpoints
+	_, err := s.Update(repo, model.Schema.Repository.Endpoints)
+	return err
+}
+
+func (s *dbRepoStore) UpdateFailed(repo *model.Repository, status model.FetchStatus) error {
+	repo.Status = status
+	_, err := s.Update(repo,
+		model.Schema.Repository.UpdatedAt,
+		model.Schema.Repository.FetchErrorAt,
+		model.Schema.Repository.References,
+		model.Schema.Repository.Status,
+	)
+
+	return err
+}
+
+func (s *dbRepoStore) UpdateFetched(repo *model.Repository, fetchedAt time.Time) error {
+	repo.Status = model.Fetched
+	repo.FetchedAt = &fetchedAt
+	repo.LastCommitAt = lastCommitTime(repo.References)
+
+	_, err := s.Update(repo,
+		model.Schema.Repository.UpdatedAt,
+		model.Schema.Repository.FetchedAt,
+		model.Schema.Repository.LastCommitAt,
+		model.Schema.Repository.Status,
+		model.Schema.Repository.References,
+	)
+
+	return err
+}
+
+func lastCommitTime(refs []*model.Reference) *time.Time {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	var last time.Time
+	for _, ref := range refs {
+		if last.Before(ref.Time) {
+			last = ref.Time
+		}
+	}
+
+	return &last
+}

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -1,0 +1,142 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	core "gopkg.in/src-d/core-retrieval.v0"
+	"gopkg.in/src-d/core-retrieval.v0/model"
+	kallax "gopkg.in/src-d/go-kallax.v1"
+)
+
+type DatabaseSuite struct {
+	suite.Suite
+	store    *dbRepoStore
+	rawStore *model.RepositoryStore
+}
+
+func (s *DatabaseSuite) SetupTest() {
+	db := core.Database()
+	s.rawStore = model.NewRepositoryStore(db)
+	s.store = FromDatabase(db).(*dbRepoStore)
+}
+
+func (s *DatabaseSuite) TearDownTest() {
+	s.rawStore.RawExec("DELETE FROM repositories")
+}
+
+func (s *DatabaseSuite) TestGet() {
+	require := s.Require()
+
+	expected := s.createRepo(model.Pending, "foo")
+	repo, err := s.store.Get(expected.ID)
+	require.NoError(err)
+	require.Equal(expected.ID, repo.ID)
+	require.Equal(expected.Endpoints, repo.Endpoints)
+	require.Equal(expected.Status, repo.Status)
+
+	repo, err = s.store.Get(kallax.NewULID())
+	require.Equal(kallax.ErrNotFound, err)
+}
+
+func (s *DatabaseSuite) TestGetByEndpoints() {
+	require := s.Require()
+
+	repos := []*model.Repository{
+		s.createRepo(model.Pending, "foo"),
+		s.createRepo(model.Pending, "bar"),
+		s.createRepo(model.Pending, "baz", "bar"),
+		s.createRepo(model.Pending, "baz"),
+	}
+
+	result, err := s.store.GetByEndpoints("bar", "baz")
+	require.Len(result, 3)
+	require.NoError(err)
+	require.Equal(repos[1].ID, result[0].ID)
+	require.Equal(repos[2].ID, result[1].ID)
+	require.Equal(repos[3].ID, result[2].ID)
+
+	result, err = s.store.GetByEndpoints("notfound")
+	require.Len(result, 0)
+	require.NoError(err)
+}
+
+func (s *DatabaseSuite) TestSetStatus() {
+	require := s.Require()
+	repo := s.createRepo(model.Pending, "foo")
+
+	err := s.store.SetStatus(repo, model.Fetching)
+	require.NoError(err)
+	require.Equal(model.Fetching, repo.Status)
+
+	repo, err = s.store.Get(repo.ID)
+	require.NoError(err)
+	require.Equal(model.Fetching, repo.Status)
+}
+
+func (s *DatabaseSuite) TestSetEndpoints() {
+	require := s.Require()
+	repo := s.createRepo(model.Pending, "foo")
+
+	endpoints := []string{"bar", "baz"}
+	err := s.store.SetEndpoints(repo, endpoints...)
+	require.NoError(err)
+	require.Len(repo.Endpoints, 2)
+	require.Equal(endpoints, repo.Endpoints)
+
+	repo, err = s.store.Get(repo.ID)
+	require.NoError(err)
+	require.Equal(endpoints, repo.Endpoints)
+}
+
+func (s *DatabaseSuite) TestUpdateFailed() {
+	require := s.Require()
+	repo := s.createRepo(model.Fetching, "foo")
+
+	err := s.store.UpdateFailed(repo, model.Pending)
+	require.NoError(err)
+	require.Equal(model.Pending, repo.Status)
+
+	repo, err = s.store.Get(repo.ID)
+	require.NoError(err)
+	require.Equal(model.Pending, repo.Status)
+}
+
+func (s *DatabaseSuite) TestUpdateFetched() {
+	require := s.Require()
+	repo := s.createRepo(model.Fetching, "foo")
+	time := withoutNs(time.Now())
+
+	err := s.store.UpdateFetched(repo, time)
+	require.NoError(err)
+	require.Len(repo.Endpoints, 1)
+	require.Equal(&time, repo.FetchedAt)
+	require.Equal(model.Fetched, repo.Status)
+
+	repo, err = s.store.Get(repo.ID)
+	require.NoError(err)
+	require.Equal(model.Fetched, repo.Status)
+}
+
+func (s *DatabaseSuite) createRepo(status model.FetchStatus, remotes ...string) *model.Repository {
+	repo := model.NewRepository()
+	repo.Status = status
+	repo.Endpoints = remotes
+	s.Require().NoError(s.rawStore.Insert(repo))
+
+	repo.CreatedAt = withoutNs(repo.CreatedAt)
+	repo.UpdatedAt = withoutNs(repo.UpdatedAt)
+
+	_, err := s.rawStore.Update(repo)
+	s.Require().NoError(err)
+	return repo
+}
+
+func withoutNs(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, t.Location())
+}
+
+func TestDatabase(t *testing.T) {
+	suite.Run(t, new(DatabaseSuite))
+}

--- a/storage/local.go
+++ b/storage/local.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"gopkg.in/src-d/core-retrieval.v0/model"
+	kallax "gopkg.in/src-d/go-kallax.v1"
+)
+
+type localRepo struct {
+	ID       kallax.ULID
+	Endpoint string
+	Status   model.FetchStatus
+}
+
+func (r *localRepo) toRepo() *model.Repository {
+	return &model.Repository{
+		ID:        r.ID,
+		Status:    r.Status,
+		Endpoints: []string{r.Endpoint},
+	}
+}
+
+type localRepoStore struct {
+	sync.RWMutex
+	repos map[kallax.ULID]*localRepo
+}
+
+// Local creates a new local repository store that needs no database connection.
+func Local() RepoStore {
+	return &localRepoStore{
+		repos: make(map[kallax.ULID]*localRepo),
+	}
+}
+
+func (s *localRepoStore) Create(repo *model.Repository) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if len(repo.Endpoints) != 1 {
+		return fmt.Errorf("expecting only 1 endpoint for repo %q, got %d", repo.ID, len(repo.Endpoints))
+	}
+
+	s.repos[repo.ID] = &localRepo{
+		ID:       repo.ID,
+		Endpoint: repo.Endpoints[0],
+		Status:   repo.Status,
+	}
+	return nil
+}
+
+func (s *localRepoStore) Get(id kallax.ULID) (*model.Repository, error) {
+	s.RLock()
+	defer s.RUnlock()
+	repo, ok := s.repos[id]
+	if !ok {
+		return nil, kallax.ErrNotFound
+	}
+
+	return repo.toRepo(), nil
+}
+
+func (s *localRepoStore) GetByEndpoints(endpoints ...string) ([]*model.Repository, error) {
+	if len(endpoints) == 0 {
+		return nil, nil
+	}
+
+	s.RLock()
+	defer s.RUnlock()
+
+	var repos []*model.Repository
+	for _, repo := range s.repos {
+		if containsString(endpoints, repo.Endpoint) {
+			repos = append(repos, repo.toRepo())
+		}
+	}
+
+	return repos, nil
+}
+
+func (s *localRepoStore) SetStatus(repo *model.Repository, status model.FetchStatus) error {
+	s.Lock()
+	defer s.Unlock()
+
+	repo.Status = status
+	localRepo, ok := s.repos[repo.ID]
+	if !ok {
+		return kallax.ErrNotFound
+	}
+
+	localRepo.Status = status
+	return nil
+}
+
+func (s *localRepoStore) SetEndpoints(repo *model.Repository, endpoints ...string) error {
+	if len(endpoints) != 1 {
+		return fmt.Errorf("expecting only 1 endpoint for repo %q, got %d", repo.ID, len(endpoints))
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	repo.Endpoints = endpoints
+	localRepo, ok := s.repos[repo.ID]
+	if !ok {
+		return kallax.ErrNotFound
+	}
+
+	localRepo.Endpoint = endpoints[0]
+	return nil
+}
+
+func (s *localRepoStore) UpdateFailed(repo *model.Repository, status model.FetchStatus) error {
+	return s.SetStatus(repo, status)
+}
+
+func (s *localRepoStore) UpdateFetched(repo *model.Repository, fetchedAt time.Time) error {
+	repo.FetchedAt = &fetchedAt
+	return s.SetStatus(repo, model.Fetched)
+}
+
+func containsString(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -1,0 +1,146 @@
+package storage
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"gopkg.in/src-d/core-retrieval.v0/model"
+	kallax "gopkg.in/src-d/go-kallax.v1"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type LocalSuite struct {
+	suite.Suite
+	store *localRepoStore
+}
+
+func (s *LocalSuite) SetupTest() {
+	s.store = Local().(*localRepoStore)
+}
+
+func (s *LocalSuite) TestGet() {
+	require := s.Require()
+
+	id := kallax.NewULID()
+	expected := &localRepo{
+		ID:       id,
+		Endpoint: "foo",
+		Status:   model.Pending,
+	}
+	s.store.repos[id] = expected
+	repo, err := s.store.Get(id)
+	require.NoError(err)
+	require.Equal(expected.toRepo(), repo)
+
+	repo, err = s.store.Get(kallax.NewULID())
+	require.Equal(kallax.ErrNotFound, err)
+}
+
+func (s *LocalSuite) TestGetByEndpoints() {
+	require := s.Require()
+
+	var ids []kallax.ULID
+	for i := 0; i < 3; i++ {
+		ids = append(ids, kallax.NewULID())
+	}
+	repos := []*localRepo{
+		{ids[0], "foo", model.Pending},
+		{ids[1], "bar", model.Pending},
+		{ids[2], "baz", model.Pending},
+	}
+
+	for i, id := range ids {
+		s.store.repos[id] = repos[i]
+	}
+
+	result, err := s.store.GetByEndpoints("foo", "baz")
+	require.Len(result, 2)
+	require.NoError(err)
+	var endpoints []string
+	for _, repo := range result {
+		endpoints = append(endpoints, repo.Endpoints...)
+	}
+	sort.Strings(endpoints)
+	require.Equal([]string{"baz", "foo"}, endpoints)
+
+	result, err = s.store.GetByEndpoints("notfound")
+	require.Len(result, 0)
+	require.NoError(err)
+}
+
+func (s *LocalSuite) TestSetStatus() {
+	require := s.Require()
+	repo := &localRepo{
+		ID:       kallax.NewULID(),
+		Endpoint: "foo",
+		Status:   model.Pending,
+	}
+	s.store.repos[repo.ID] = repo
+	modelRepo := repo.toRepo()
+
+	err := s.store.SetStatus(modelRepo, model.Fetching)
+	require.NoError(err)
+	require.Equal(model.Fetching, modelRepo.Status)
+	require.Equal(model.Fetching, s.store.repos[repo.ID].Status)
+}
+
+func (s *LocalSuite) TestSetEndpoints() {
+	require := s.Require()
+	repo := &localRepo{
+		ID:       kallax.NewULID(),
+		Endpoint: "foo",
+		Status:   model.Pending,
+	}
+	s.store.repos[repo.ID] = repo
+	modelRepo := repo.toRepo()
+
+	err := s.store.SetEndpoints(modelRepo, "bar")
+	require.NoError(err)
+	require.Len(modelRepo.Endpoints, 1)
+	require.Equal("bar", modelRepo.Endpoints[0])
+	require.Equal("bar", s.store.repos[repo.ID].Endpoint)
+
+	err = s.store.SetEndpoints(modelRepo, "bar", "baz")
+	require.Error(err)
+}
+
+func (s *LocalSuite) TestUpdateFailed() {
+	require := s.Require()
+	repo := &localRepo{
+		ID:       kallax.NewULID(),
+		Endpoint: "foo",
+		Status:   model.Fetched,
+	}
+	s.store.repos[repo.ID] = repo
+	modelRepo := repo.toRepo()
+
+	err := s.store.UpdateFailed(modelRepo, model.Pending)
+	require.NoError(err)
+	require.Equal(model.Pending, modelRepo.Status)
+	require.Equal(model.Pending, s.store.repos[repo.ID].Status)
+}
+
+func (s *LocalSuite) TestUpdateFetched() {
+	require := s.Require()
+	repo := &localRepo{
+		ID:       kallax.NewULID(),
+		Endpoint: "foo",
+		Status:   model.Pending,
+	}
+	s.store.repos[repo.ID] = repo
+	modelRepo := repo.toRepo()
+	time := time.Now()
+
+	err := s.store.UpdateFetched(modelRepo, time)
+	require.NoError(err)
+	require.Len(modelRepo.Endpoints, 1)
+	require.Equal(&time, modelRepo.FetchedAt)
+	require.Equal(model.Fetched, modelRepo.Status)
+	require.Equal(model.Fetched, s.store.repos[repo.ID].Status)
+}
+
+func TestLocal(t *testing.T) {
+	suite.Run(t, new(LocalSuite))
+}

--- a/storage/repostore.go
+++ b/storage/repostore.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"time"
+
+	"gopkg.in/src-d/core-retrieval.v0/model"
+	kallax "gopkg.in/src-d/go-kallax.v1"
+)
+
+// RepoStore is the access layer to the storage of repositories.
+type RepoStore interface {
+	// Create inserts a new Repository in the store.
+	Create(repo *model.Repository) error
+	// Get returns a Repository given its ID.
+	Get(id kallax.ULID) (*model.Repository, error)
+	// GetByEndpoints returns the Repositories that have common endpoints with the
+	// list of endpoints passed.
+	GetByEndpoints(endpoints ...string) ([]*model.Repository, error)
+	// SetStatus changes the status of the given repository.
+	SetStatus(repo *model.Repository, status model.FetchStatus) error
+	// SetEndpoints updates the endpoints of the repository.
+	SetEndpoints(repo *model.Repository, endpoints ...string) error
+	// UpdateFailed updates the given repository as failed with the given
+	// status. No modifications are performed to the repository itself
+	// other than setting its status, all the modification to the repo
+	// fields must be done before calling this method. That is, changing
+	// FetchErrorAt and so on should be done manually before. Refer to the
+	// concrete implementation to know what is being updated.
+	UpdateFailed(repo *model.Repository, status model.FetchStatus) error
+	// Update updates the given repository as successfully fetched.
+	// No modifications are performed to the repository other than setting
+	// the Fetched status and the time when it was fetched, all other changes
+	// should be done to the repo before calling this method. Refer to the
+	// concrete implementation to know what is being updated.
+	UpdateFetched(repo *model.Repository, fetchedAt time.Time) error
+}


### PR DESCRIPTION
The future `borges pack` command will not require a database, which requires a small refactor abstracting the logic of how repositories are stored and their status managed.
This PR introduces a RepoStore abstraction that has two implementations: Database and Local, depending on the needed use. The Database implementation does the same it did before without the abstraction and the Local one is just a map for keeping track of the repositories with a mutex for making it thread-safe across all workers.

This will not be merged in master (even though it could), but on a `feature/packer` feature branch that will be merged as a whole when the pack command is ready.