### PR TITLE
git: install only one protocol for the whole app

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -288,7 +288,7 @@ func (a *Archiver) pushChangesToRootedRepository(ctx context.Context, log log15.
 		return err
 	}
 
-	return WithInProcRepository(rr, func(url string) error {
+	return withInProcRepository(ic, rr, func(url string) error {
 		if err := StoreConfig(rr, r); err != nil {
 			_ = tx.Rollback()
 			return err

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -99,7 +99,8 @@ func (s *ArchiverSuite) TestCheckTimeout() {
 			var rid kallax.ULID
 			r, err := ct.OldRepository()
 			require.NoError(err)
-			err = WithInProcRepository(r, func(url string) error {
+			var hash model.SHA1
+			err = withInProcRepository(hash, r, func(url string) error {
 				rid = s.newRepositoryModel(url)
 				return s.a.Do(&Job{RepositoryID: uuid.UUID(rid)})
 			})
@@ -130,11 +131,12 @@ func (s *ArchiverSuite) TestFixtures() {
 	for _, ct := range ChangesFixtures {
 		s.T().Run(ct.TestName, func(t *testing.T) {
 			require := require.New(t)
+			var hash model.SHA1
 
 			or, err := ct.OldRepository()
 			var rid kallax.ULID
 			// emulate initial status of a repository
-			err = WithInProcRepository(or, func(url string) error {
+			err = withInProcRepository(hash, or, func(url string) error {
 				rid = s.newRepositoryModel(url)
 				return s.a.Do(&Job{RepositoryID: uuid.UUID(rid)})
 			})
@@ -143,7 +145,7 @@ func (s *ArchiverSuite) TestFixtures() {
 			nr, err := ct.NewRepository()
 			require.NoError(err)
 
-			err = WithInProcRepository(nr, func(url string) error {
+			err = withInProcRepository(hash, nr, func(url string) error {
 				mr, err := s.rawStore.FindOne(model.NewRepositoryQuery().FindByID(rid))
 				require.NoError(err)
 				mr.Endpoints = nil


### PR DESCRIPTION
Closes #181 

Introduces a new `sivaLoader` to which more mappings between siva hashes and storers can be added dynamically, removing the need to install and remove a new protocol each time WithInProcRepository is called. This solves the synchronization problem of the client map in go-git, which could lead to panics because of concurrent map writes and reads.

The protocol used is `siva://[rooted repo hash]`. Note that hash is just an identifier for a concrete repository storer, it could perfectly be a random number and it would work just as fine. This is because the RootedTransactioner already returns the storer, there is no need to pass the file path in the protocol and open it again when it's already opened.

When we get rid of the config part in the git directory we might be able to move all the rootedtransactioner logic inside `WithInProcRepository`.