### PR TITLE
Correctly delete local_repos temporary dirs

### DIFF
--- a/git.go
+++ b/git.go
@@ -252,8 +252,11 @@ func (b *temporaryRepositoryBuilder) Clone(
 	ctx context.Context,
 	id, endpoint string,
 ) (TemporaryRepository, error) {
-	dir := filepath.Join("local_repos", id,
-		strconv.FormatInt(time.Now().UnixNano(), 10))
+	dir := filepath.Join(
+		"local_repos",
+		fmt.Sprintf("%s_%s",
+			id,
+			strconv.FormatInt(time.Now().UnixNano(), 10)))
 
 	tmpFs, err := b.TempFilesystem.Chroot(dir)
 	if err != nil {


### PR DESCRIPTION
Use only one level directory to store local_repos. This makes possible
to delete the whole tree.

Before it was creating directories like this:

    015f923c-a989-88bd-8168-dc79dff24a9d
    015f923c-a984-1fed-57ba-0e1311ae34e1
    015f923c-a984-1fed-57ba-0e1311ae34e1/1510671721316442023

Now the directories only have one level:

    015f923c-a996-aa5b-581a-f400ab37ffd6_1510671723291729698
    015f923c-a992-9e39-42e8-30af6b8b21b7_1510671722254221984
    015f923c-a990-a6bf-7776-1bb35a6f4177_1510671721920332662