### PR TITLE
Explicitly close etcd lock session after each job

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -423,7 +423,12 @@ func NewArchiverWorkerPool(
 			return err
 		}
 
-		defer lsess.Close()
+		defer func() {
+			err := lsess.Close()
+			if err != nil {
+				log.Error("error closing locking session", "error", err)
+			}
+		}()
 
 		a := NewArchiver(log, r, tx, tc, lsess, to)
 		return a.Do(j)

--- a/archiver.go
+++ b/archiver.go
@@ -423,6 +423,8 @@ func NewArchiverWorkerPool(
 			return err
 		}
 
+		defer lsess.Close()
+
 		a := NewArchiver(log, r, tx, tc, lsess, to)
 		return a.Do(j)
 	}


### PR DESCRIPTION
Leaving the session opened causes problems when too many jobs a created
in a small amount of time. Each session opened creates a keepalive
goroutine and can consume all stack ("fatal: morestack on g0" error).

fixes #186