### PR TITLE
Add profiler and metrics options to pack command

### DIFF
--- a/cli/borges/packer.go
+++ b/cli/borges/packer.go
@@ -21,7 +21,7 @@ const (
 )
 
 type packerCmd struct {
-	loggerCmd
+	cmd
 	File      string `long:"file" short:"f" required:"true" description:"file with the repositories to pack (one per line)"`
 	OutputDir string `long:"to" default:"repositories" description:"path to store the packed siva files"`
 	Timeout   string `long:"timeout" default:"30m" description:"time to wait to consider a job failed"`


### PR DESCRIPTION
`--profiler` option is very useful for debug and sometimes pack is more convenient to test things than a full producer consumer setup.