### PR TITLE
Improvement/catch stacktraces

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	goerrors "github.com/go-errors/errors"
 	"github.com/inconshreveable/log15"
 	"github.com/jpillora/backoff"
 	"github.com/src-d/borges/metrics"
@@ -141,7 +142,7 @@ func (a *Archiver) do(log log15.Logger, j *Job) (err error) {
 				log15.Error("error setting repo as failed", "id", r.ID, "err", err)
 			}
 
-			err = fmt.Errorf("%v", rcv)
+			err = fmt.Errorf("%v", goerrors.Wrap(rcv, 3).ErrorStack())
 		}
 	}()
 

--- a/archiver.go
+++ b/archiver.go
@@ -141,7 +141,7 @@ func (a *Archiver) do(log log15.Logger, j *Job) (err error) {
 				log15.Error("error setting repo as failed", "id", r.ID, "err", err)
 			}
 
-			err = fmt.Errorf(rcv.(string))
+			err = fmt.Errorf("%v", rcv)
 		}
 	}()
 

--- a/archiver.go
+++ b/archiver.go
@@ -3,10 +3,10 @@ package borges
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"time"
 
-	goerrors "github.com/go-errors/errors"
 	"github.com/inconshreveable/log15"
 	"github.com/jpillora/backoff"
 	"github.com/src-d/borges/metrics"
@@ -142,7 +142,7 @@ func (a *Archiver) do(log log15.Logger, j *Job) (err error) {
 				log15.Error("error setting repo as failed", "id", r.ID, "err", err)
 			}
 
-			err = fmt.Errorf("%v", goerrors.Wrap(rcv, 3).ErrorStack())
+			err = fmt.Errorf("%v: %s", rcv, debug.Stack())
 		}
 	}()
 

--- a/archiver.go
+++ b/archiver.go
@@ -132,6 +132,19 @@ func (a *Archiver) do(log log15.Logger, j *Job) (err error) {
 		"last-fetch", r.FetchedAt,
 		"references", len(r.References))
 
+	defer func() {
+		if rcv := recover(); rcv != nil {
+			log.Error("panic while processing repository", "error", rcv)
+
+			r.FetchErrorAt = &now
+			if sErr := a.Store.UpdateFailed(r, model.Pending); sErr != nil {
+				log15.Error("error setting repo as failed", "id", r.ID, "err", err)
+			}
+
+			err = fmt.Errorf(rcv.(string))
+		}
+	}()
+
 	if err := a.canProcessRepository(r); err != nil {
 		log.Warn("cannot process repository",
 			"id", r.ID.String(),


### PR DESCRIPTION
<s>I found this [library]() which retrieves stacktraces from an error.

I can get the string the panic would print, so the borges logs looks pretty ugly</s>:
```
EROR[02-12|13:02:49] error on job                             module=borges worker=5 error="*errors.errorString SUPER PANIC... BOOM!\n/home/manu/go/src/github.com/src-d/borges/vendor/gopkg.in/src-d/go-git.v4/remote.go:239 (0x958b7c)\n\t(*Remote).FetchContext: panic(\"SUPER PANIC... BOOM!\")\n/home/manu/go/src/github.com/src-d/borges/git.go:289 (0xb2f9cf)\n\t(*temporaryRepositoryBuilder).Clone: err = remote.FetchContext(ctx, o)\n/home/manu/go/src/github.com/src-d/borges/archiver.go:174 (0xb2656d)\n\t(*Archiver).do: gr, err := a.TemporaryCloner.Clone(\n/home/manu/go/src/github.com/src-d/borges/archiver.go:99 (0xb25984)\n\t(*Archiver).Do: if err := a.do(log, j); err != nil {\n/home/manu/go/src/github.com/src-d/borges/archiver.go:504 (0xb35284)\n\tNewArchiverWorkerPool.func1: return a.Do(j)\n/home/manu/go/src/github.com/src-d/borges/worker.go:45 (0xb332e5)\n\t(*Worker).Start: if err := w.do(log, job.Job); err != nil {\n/home/manu/go/src/github.com/src-d/borges/worker_pool.go:77 (0xb35c65)\n\t(*WorkerPool).add.func1: w.Start()\n/usr/local/go/src/runtime/asm_amd64.s:2337 (0x45e111)\n\tgoexit: BYTE\t$0x90\t// NOP\n" caller=worker.go:50
```

Eventually, it just uses the standard library to get a stack trace with `runtime.Stack()`

This PR comes from https://github.com/src-d/borges/pull/228#pullrequestreview-95419524,
 but how that PR is used too in #233 I'm splitting this improvement in this other PR.