### PR TITLE
Update go-git to 4.2.1 and go-billy to 4.1.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -359,9 +359,9 @@
     "osfs",
     "util"
   ]
-  revision = "027dceab1aa836eb310d92c2eb2266e4dc9f4b81"
+  revision = "df053870ae7070b0350624ba5a22161ba3796cc0"
   source = "https://github.com/src-d/go-billy.git"
-  version = "v4.1.0"
+  version = "v4.1.1"
 
 [[projects]]
   name = "gopkg.in/src-d/go-errors.v0"
@@ -419,9 +419,9 @@
     "utils/merkletrie/internal/frame",
     "utils/merkletrie/noder"
   ]
-  revision = "1d28459504251497e0ce6132a0fadd5eb44ffd22"
+  revision = "247cf690745dfd67ccd9f0c07878e6dd85e6c9ed"
   source = "https://github.com/src-d/go-git.git"
-  version = "v4.2.0"
+  version = "v4.2.1"
 
 [[projects]]
   name = "gopkg.in/src-d/go-kallax.v1"
@@ -456,6 +456,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7933de107f4858acec7eb3f6a24a0efad2156c2c2418334900e7d629cf1f786c"
+  inputs-digest = "1b981a90541df45f095752ded5b4ea6143a3760797d90314a1b530d0577e7d8e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,7 +33,7 @@
 [[constraint]]
   name = "gopkg.in/src-d/go-git.v4"
   source = "https://github.com/src-d/go-git.git"
-  version = "4.2.0"
+  version = "4.2.1"
 
 [[constraint]]
   name = "gopkg.in/src-d/go-kallax.v1"

--- a/vendor/gopkg.in/src-d/go-billy.v4/helper/mount/mount.go
+++ b/vendor/gopkg.in/src-d/go-billy.v4/helper/mount/mount.go
@@ -228,12 +228,12 @@ func copyPath(src, dst billy.Basic, srcPath, dstPath string) error {
 
 	srcFile, err := src.Open(srcPath)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	_, err = io.Copy(dstFile, srcFile)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	err = dstFile.Close()

--- a/vendor/gopkg.in/src-d/go-git.v4/blame.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/blame.go
@@ -109,12 +109,15 @@ type Line struct {
 	Text string
 	// Date is when the original text of the line was introduced
 	Date time.Time
+	// Hash is the commit hash that introduced the original line
+	Hash plumbing.Hash
 }
 
-func newLine(author, text string, date time.Time) *Line {
+func newLine(author, text string, date time.Time, hash plumbing.Hash) *Line {
 	return &Line{
 		Author: author,
 		Text:   text,
+		Hash:   hash,
 		Date:   date,
 	}
 }
@@ -125,7 +128,7 @@ func newLines(contents []string, commits []*object.Commit) ([]*Line, error) {
 	}
 	result := make([]*Line, 0, len(contents))
 	for i := range contents {
-		l := newLine(commits[i].Author.Email, contents[i], commits[i].Author.When)
+		l := newLine(commits[i].Author.Email, contents[i], commits[i].Author.When, commits[i].Hash)
 		result = append(result, l)
 	}
 	return result, nil

--- a/vendor/gopkg.in/src-d/go-git.v4/blame_test.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/blame_test.go
@@ -32,6 +32,10 @@ func (s *BlameSuite) TestBlame(c *C) {
 		obt, err := Blame(commit, t.path)
 		c.Assert(err, IsNil)
 		c.Assert(obt, DeepEquals, exp)
+
+		for i, l := range obt.Lines {
+			c.Assert(l.Hash.String(), Equals, t.blames[i])
+		}
 	}
 }
 
@@ -54,6 +58,7 @@ func (s *BlameSuite) mockBlame(c *C, t blameTest, r *Repository) (blame *BlameRe
 			Author: commit.Author.Email,
 			Text:   lines[i],
 			Date:   commit.Author.When,
+			Hash:   commit.Hash,
 		}
 		blamedLines = append(blamedLines, l)
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/config/refspec.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/config/refspec.go
@@ -62,7 +62,13 @@ func (s RefSpec) IsDelete() bool {
 // Src return the src side.
 func (s RefSpec) Src() string {
 	spec := string(s)
-	start := strings.Index(spec, refSpecForce) + 1
+
+	var start int
+	if s.IsForceUpdate() {
+		start = 1
+	} else {
+		start = 0
+	}
 	end := strings.Index(spec, refSpecSeparator)
 
 	return spec[start:end]

--- a/vendor/gopkg.in/src-d/go-git.v4/config/refspec_test.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/config/refspec_test.go
@@ -62,8 +62,17 @@ func (s *RefSpecSuite) TestRefSpecSrc(c *C) {
 	spec := RefSpec("refs/heads/*:refs/remotes/origin/*")
 	c.Assert(spec.Src(), Equals, "refs/heads/*")
 
+	spec = RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	c.Assert(spec.Src(), Equals, "refs/heads/*")
+
 	spec = RefSpec(":refs/heads/master")
 	c.Assert(spec.Src(), Equals, "")
+
+	spec = RefSpec("refs/heads/love+hate:refs/heads/love+hate")
+	c.Assert(spec.Src(), Equals, "refs/heads/love+hate")
+
+	spec = RefSpec("+refs/heads/love+hate:refs/heads/love+hate")
+	c.Assert(spec.Src(), Equals, "refs/heads/love+hate")
 }
 
 func (s *RefSpecSuite) TestRefSpecMatch(c *C) {
@@ -71,9 +80,19 @@ func (s *RefSpecSuite) TestRefSpecMatch(c *C) {
 	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/foo")), Equals, false)
 	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/master")), Equals, true)
 
+	spec = RefSpec("+refs/heads/master:refs/remotes/origin/master")
+	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/foo")), Equals, false)
+	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/master")), Equals, true)
+
 	spec = RefSpec(":refs/heads/master")
 	c.Assert(spec.Match(plumbing.ReferenceName("")), Equals, true)
 	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/master")), Equals, false)
+
+	spec = RefSpec("refs/heads/love+hate:heads/love+hate")
+	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/love+hate")), Equals, true)
+
+	spec = RefSpec("+refs/heads/love+hate:heads/love+hate")
+	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/love+hate")), Equals, true)
 }
 
 func (s *RefSpecSuite) TestRefSpecMatchGlob(c *C) {

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/common.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/common.go
@@ -40,8 +40,7 @@ func UpdateObjectStorage(s storer.EncodedObjectStorer, packfile io.Reader) error
 	return err
 }
 
-func writePackfileToObjectStorage(sw storer.PackfileWriter, packfile io.Reader) error {
-	var err error
+func writePackfileToObjectStorage(sw storer.PackfileWriter, packfile io.Reader) (err error) {
 	w, err := sw.PackfileWriter()
 	if err != nil {
 		return err

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/encoder_advanced_test.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/encoder_advanced_test.go
@@ -3,6 +3,7 @@ package packfile_test
 import (
 	"bytes"
 	"math/rand"
+	"testing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	. "gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
@@ -21,6 +22,10 @@ type EncoderAdvancedSuite struct {
 var _ = Suite(&EncoderAdvancedSuite{})
 
 func (s *EncoderAdvancedSuite) TestEncodeDecode(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	fixs := fixtures.Basic().ByTag("packfile").ByTag(".git")
 	fixs = append(fixs, fixtures.ByURL("https://github.com/src-d/go-git.git").
 		ByTag("packfile").ByTag(".git").One())
@@ -33,6 +38,10 @@ func (s *EncoderAdvancedSuite) TestEncodeDecode(c *C) {
 }
 
 func (s *EncoderAdvancedSuite) TestEncodeDecodeNoDeltaCompression(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	fixs := fixtures.Basic().ByTag("packfile").ByTag(".git")
 	fixs = append(fixs, fixtures.ByURL("https://github.com/src-d/go-git.git").
 		ByTag("packfile").ByTag(".git").One())

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/scanner.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/scanner.go
@@ -279,14 +279,15 @@ func (s *Scanner) NextObject(w io.Writer) (written int64, crc32 uint32, err erro
 // from it zlib stream in an object entry in the packfile.
 func (s *Scanner) copyObject(w io.Writer) (n int64, err error) {
 	if s.zr == nil {
-		zr, err := zlib.NewReader(s.r)
+		var zr io.ReadCloser
+		zr, err = zlib.NewReader(s.r)
 		if err != nil {
 			return 0, fmt.Errorf("zlib initialization error: %s", err)
 		}
 
 		s.zr = zr.(readerResetter)
 	} else {
-		if err := s.zr.Reset(s.r, nil); err != nil {
+		if err = s.zr.Reset(s.r, nil); err != nil {
 			return 0, fmt.Errorf("zlib reset error: %s", err)
 		}
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/pktline/encoder.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/pktline/encoder.go
@@ -17,6 +17,9 @@ type Encoder struct {
 const (
 	// MaxPayloadSize is the maximum payload size of a pkt-line in bytes.
 	MaxPayloadSize = 65516
+
+	// For compatibility with canonical Git implementation, accept longer pkt-lines
+	OversizePayloadMax = 65520
 )
 
 var (

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/pktline/scanner.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/pktline/scanner.go
@@ -97,7 +97,7 @@ func (s *Scanner) readPayloadLen() (int, error) {
 		return 0, nil
 	case n <= lenSize:
 		return 0, ErrInvalidPktLen
-	case n > MaxPayloadSize+lenSize:
+	case n > OversizePayloadMax+lenSize:
 		return 0, ErrInvalidPktLen
 	default:
 		return n - lenSize, nil

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/pktline/scanner_test.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/pktline/scanner_test.go
@@ -20,7 +20,7 @@ func (s *SuiteScanner) TestInvalid(c *C) {
 	for _, test := range [...]string{
 		"0001", "0002", "0003", "0004",
 		"0001asdfsadf", "0004foo",
-		"fff1", "fff2",
+		"fff5", "ffff",
 		"gorka",
 		"0", "003",
 		"   5a", "5   a", "5   \n",
@@ -31,6 +31,20 @@ func (s *SuiteScanner) TestInvalid(c *C) {
 		_ = sc.Scan()
 		c.Assert(sc.Err(), ErrorMatches, pktline.ErrInvalidPktLen.Error(),
 			Commentf("data = %q", test))
+	}
+}
+
+func (s *SuiteScanner) TestDecodeOversizePktLines(c *C) {
+	for _, test := range [...]string{
+		"fff1" + strings.Repeat("a", 0xfff1),
+		"fff2" + strings.Repeat("a", 0xfff2),
+		"fff3" + strings.Repeat("a", 0xfff3),
+		"fff4" + strings.Repeat("a", 0xfff4),
+	} {
+		r := strings.NewReader(test)
+		sc := pktline.NewScanner(r)
+		_ = sc.Scan()
+		c.Assert(sc.Err(), IsNil)
 	}
 }
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/blob.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/blob.go
@@ -67,7 +67,7 @@ func (b *Blob) Decode(o plumbing.EncodedObject) error {
 }
 
 // Encode transforms a Blob into a plumbing.EncodedObject.
-func (b *Blob) Encode(o plumbing.EncodedObject) error {
+func (b *Blob) Encode(o plumbing.EncodedObject) (err error) {
 	o.SetType(plumbing.BlobObject)
 
 	w, err := o.Writer()

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/commit.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/commit.go
@@ -226,7 +226,7 @@ func (b *Commit) Encode(o plumbing.EncodedObject) error {
 	return b.encode(o, true)
 }
 
-func (b *Commit) encode(o plumbing.EncodedObject, includeSig bool) error {
+func (b *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	o.SetType(plumbing.CommitObject)
 	w, err := o.Writer()
 	if err != nil {

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/file.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/file.go
@@ -44,7 +44,7 @@ func (f *File) Contents() (content string, err error) {
 }
 
 // IsBinary returns if the file is binary or not
-func (f *File) IsBinary() (bool, error) {
+func (f *File) IsBinary() (bin bool, err error) {
 	reader, err := f.Reader()
 	if err != nil {
 		return false, err

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/tag.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/tag.go
@@ -95,7 +95,8 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 
 	r := bufio.NewReader(reader)
 	for {
-		line, err := r.ReadBytes('\n')
+		var line []byte
+		line, err = r.ReadBytes('\n')
 		if err != nil && err != io.EOF {
 			return err
 		}
@@ -168,7 +169,7 @@ func (t *Tag) Encode(o plumbing.EncodedObject) error {
 	return t.encode(o, true)
 }
 
-func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) error {
+func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	o.SetType(plumbing.TagObject)
 	w, err := o.Writer()
 	if err != nil {

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/tree.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/tree.go
@@ -233,7 +233,7 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 }
 
 // Encode transforms a Tree into a plumbing.EncodedObject.
-func (t *Tree) Encode(o plumbing.EncodedObject) error {
+func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	o.SetType(plumbing.TreeObject)
 	w, err := o.Writer()
 	if err != nil {
@@ -242,7 +242,7 @@ func (t *Tree) Encode(o plumbing.EncodedObject) error {
 
 	defer ioutil.CheckClose(w, &err)
 	for _, entry := range t.Entries {
-		if _, err := fmt.Fprintf(w, "%o %s", entry.Mode, entry.Name); err != nil {
+		if _, err = fmt.Fprintf(w, "%o %s", entry.Mode, entry.Name); err != nil {
 			return err
 		}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/advrefs_test.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/advrefs_test.go
@@ -79,6 +79,79 @@ func (s *AdvRefSuite) TestAllReferencesBadSymref(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (s *AdvRefSuite) TestNoSymRefCapabilityHeadToMaster(c *C) {
+	a := NewAdvRefs()
+	headHash := plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c")
+	a.Head = &headHash
+	ref := plumbing.NewHashReference(plumbing.Master, plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c"))
+
+	err := a.AddReference(ref)
+	c.Assert(err, IsNil)
+
+	storage, err := a.AllReferences()
+	c.Assert(err, IsNil)
+
+	head, err := storage.Reference(plumbing.HEAD)
+	c.Assert(err, IsNil)
+	c.Assert(head.Target(), Equals, ref.Name())
+}
+
+func (s *AdvRefSuite) TestNoSymRefCapabilityHeadToOtherThanMaster(c *C) {
+	a := NewAdvRefs()
+	headHash := plumbing.NewHash("0000000000000000000000000000000000000000")
+	a.Head = &headHash
+	ref1 := plumbing.NewHashReference(plumbing.Master, plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c"))
+	ref2 := plumbing.NewHashReference("other/ref", plumbing.NewHash("0000000000000000000000000000000000000000"))
+
+	err := a.AddReference(ref1)
+	c.Assert(err, IsNil)
+	err = a.AddReference(ref2)
+	c.Assert(err, IsNil)
+
+	storage, err := a.AllReferences()
+	c.Assert(err, IsNil)
+
+	head, err := storage.Reference(plumbing.HEAD)
+	c.Assert(err, IsNil)
+	c.Assert(head.Hash(), Equals, ref2.Hash())
+}
+
+func (s *AdvRefSuite) TestNoSymRefCapabilityHeadToNoRef(c *C) {
+	a := NewAdvRefs()
+	headHash := plumbing.NewHash("0000000000000000000000000000000000000000")
+	a.Head = &headHash
+	ref := plumbing.NewHashReference(plumbing.Master, plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c"))
+
+	err := a.AddReference(ref)
+	c.Assert(err, IsNil)
+
+	_, err = a.AllReferences()
+	c.Assert(err, NotNil)
+}
+
+func (s *AdvRefSuite) TestNoSymRefCapabilityHeadToNoMasterAlphabeticallyOrdered(c *C) {
+	a := NewAdvRefs()
+	headHash := plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c")
+	a.Head = &headHash
+	ref1 := plumbing.NewHashReference(plumbing.Master, plumbing.NewHash("0000000000000000000000000000000000000000"))
+	ref2 := plumbing.NewHashReference("aaaaaaaaaaaaaaa", plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c"))
+	ref3 := plumbing.NewHashReference("bbbbbbbbbbbbbbb", plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c"))
+
+	err := a.AddReference(ref1)
+	c.Assert(err, IsNil)
+	err = a.AddReference(ref3)
+	c.Assert(err, IsNil)
+	err = a.AddReference(ref2)
+	c.Assert(err, IsNil)
+
+	storage, err := a.AllReferences()
+	c.Assert(err, IsNil)
+
+	head, err := storage.Reference(plumbing.HEAD)
+	c.Assert(err, IsNil)
+	c.Assert(head.Target(), Equals, ref2.Name())
+}
+
 type AdvRefsDecodeEncodeSuite struct{}
 
 var _ = Suite(&AdvRefsDecodeEncodeSuite{})

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/http/common.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/http/common.go
@@ -31,7 +31,7 @@ func applyHeadersToRequest(req *http.Request, content *bytes.Buffer, host string
 
 const infoRefsPath = "/info/refs"
 
-func advertisedReferences(s *session, serviceName string) (*packp.AdvRefs, error) {
+func advertisedReferences(s *session, serviceName string) (ref *packp.AdvRefs, err error) {
 	url := fmt.Sprintf(
 		"%s%s?service=%s",
 		s.endpoint.String(), infoRefsPath, serviceName,
@@ -52,12 +52,12 @@ func advertisedReferences(s *session, serviceName string) (*packp.AdvRefs, error
 	s.ModifyEndpointIfRedirect(res)
 	defer ioutil.CheckClose(res.Body, &err)
 
-	if err := NewErr(res); err != nil {
+	if err = NewErr(res); err != nil {
 		return nil, err
 	}
 
 	ar := packp.NewAdvRefs()
-	if err := ar.Decode(res.Body); err != nil {
+	if err = ar.Decode(res.Body); err != nil {
 		if err == packp.ErrEmptyAdvRefs {
 			err = transport.ErrEmptyRemoteRepository
 		}

--- a/vendor/gopkg.in/src-d/go-git.v4/remote.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/remote.go
@@ -73,7 +73,7 @@ func (r *Remote) Push(o *PushOptions) error {
 // The provided Context must be non-nil. If the context expires before the
 // operation is complete, an error is returned. The context only affects to the
 // transport operations.
-func (r *Remote) PushContext(ctx context.Context, o *PushOptions) error {
+func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 	if err := o.Validate(); err != nil {
 		return err
 	}
@@ -243,12 +243,12 @@ func (r *Remote) Fetch(o *FetchOptions) error {
 	return r.FetchContext(context.Background(), o)
 }
 
-func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (storer.ReferenceStorer, error) {
+func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.ReferenceStorer, err error) {
 	if o.RemoteName == "" {
 		o.RemoteName = r.c.Name
 	}
 
-	if err := o.Validate(); err != nil {
+	if err = o.Validate(); err != nil {
 		return nil, err
 	}
 
@@ -295,7 +295,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (storer.ReferenceSt
 			return nil, err
 		}
 
-		if err := r.fetchPack(ctx, o, s, req); err != nil {
+		if err = r.fetchPack(ctx, o, s, req); err != nil {
 			return nil, err
 		}
 	}
@@ -354,7 +354,7 @@ func (r *Remote) fetchPack(ctx context.Context, o *FetchOptions, s transport.Upl
 
 	defer ioutil.CheckClose(reader, &err)
 
-	if err := r.updateShallow(o, reader); err != nil {
+	if err = r.updateShallow(o, reader); err != nil {
 		return err
 	}
 
@@ -872,7 +872,7 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 }
 
 // List the references on the remote repository.
-func (r *Remote) List(o *ListOptions) ([]*plumbing.Reference, error) {
+func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {
 	s, err := newUploadPackSession(r.c.URLs[0], o.Auth)
 	if err != nil {
 		return nil, err

--- a/vendor/gopkg.in/src-d/go-git.v4/repository.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/repository.go
@@ -270,9 +270,7 @@ func dotGitToOSFilesystems(path string) (dot, wt billy.Filesystem, err error) {
 	return dot, fs, nil
 }
 
-func dotGitFileToOSFilesystem(path string, fs billy.Filesystem) (billy.Filesystem, error) {
-	var err error
-
+func dotGitFileToOSFilesystem(path string, fs billy.Filesystem) (bfs billy.Filesystem, err error) {
 	f, err := fs.Open(".git")
 	if err != nil {
 		return nil, err
@@ -1092,7 +1090,7 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 	if los, ok := r.Storer.(storer.LooseObjectStorer); ok {
 		err = los.ForEachObjectHash(func(hash plumbing.Hash) error {
 			if ow.isSeen(hash) {
-				err := los.DeleteLooseObject(hash)
+				err = los.DeleteLooseObject(hash)
 				if err != nil {
 					return err
 				}

--- a/vendor/gopkg.in/src-d/go-git.v4/repository_test.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/repository_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/config"
@@ -430,6 +431,10 @@ func (s *RepositorySuite) TestPlainCloneContext(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	dir, err := ioutil.TempDir("", "plain-clone-submodule")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
@@ -1396,10 +1401,18 @@ func (s *RepositorySuite) testRepackObjects(
 }
 
 func (s *RepositorySuite) TestRepackObjects(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	s.testRepackObjects(c, time.Time{}, 1)
 }
 
 func (s *RepositorySuite) TestRepackObjectsWithNoDelete(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	s.testRepackObjects(c, time.Unix(0, 1), 3)
 }
 

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/config.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/config.go
@@ -13,7 +13,7 @@ type ConfigStorage struct {
 	dir *dotgit.DotGit
 }
 
-func (c *ConfigStorage) Config() (*config.Config, error) {
+func (c *ConfigStorage) Config() (conf *config.Config, err error) {
 	cfg := config.NewConfig()
 
 	f, err := c.dir.Config()
@@ -32,15 +32,15 @@ func (c *ConfigStorage) Config() (*config.Config, error) {
 		return nil, err
 	}
 
-	if err := cfg.Unmarshal(b); err != nil {
+	if err = cfg.Unmarshal(b); err != nil {
 		return nil, err
 	}
 
 	return cfg, err
 }
 
-func (c *ConfigStorage) SetConfig(cfg *config.Config) error {
-	if err := cfg.Validate(); err != nil {
+func (c *ConfigStorage) SetConfig(cfg *config.Config) (err error) {
+	if err = cfg.Validate(); err != nil {
 		return err
 	}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/index.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/index.go
@@ -12,7 +12,7 @@ type IndexStorage struct {
 	dir *dotgit.DotGit
 }
 
-func (s *IndexStorage) SetIndex(idx *index.Index) error {
+func (s *IndexStorage) SetIndex(idx *index.Index) (err error) {
 	f, err := s.dir.IndexWriter()
 	if err != nil {
 		return err
@@ -25,7 +25,7 @@ func (s *IndexStorage) SetIndex(idx *index.Index) error {
 	return err
 }
 
-func (s *IndexStorage) Index() (*index.Index, error) {
+func (s *IndexStorage) Index() (i *index.Index, err error) {
 	idx := &index.Index{
 		Version: 2,
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
@@ -375,7 +375,7 @@ func (d *DotGit) findPackedRefsInFile(f billy.File) ([]*plumbing.Reference, erro
 	return refs, s.Err()
 }
 
-func (d *DotGit) findPackedRefs() ([]*plumbing.Reference, error) {
+func (d *DotGit) findPackedRefs() (r []*plumbing.Reference, err error) {
 	f, err := d.fs.Open(packedRefsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -676,7 +676,7 @@ func (d *DotGit) PackRefs() (err error) {
 	// Gather all refs using addRefsFromRefDir and addRefsFromPackedRefs.
 	var refs []*plumbing.Reference
 	seen := make(map[plumbing.ReferenceName]bool)
-	if err := d.addRefsFromRefDir(&refs, seen); err != nil {
+	if err = d.addRefsFromRefDir(&refs, seen); err != nil {
 		return err
 	}
 	if len(refs) == 0 {
@@ -684,7 +684,7 @@ func (d *DotGit) PackRefs() (err error) {
 		return nil
 	}
 	numLooseRefs := len(refs)
-	if err := d.addRefsFromPackedRefsFile(&refs, f, seen); err != nil {
+	if err = d.addRefsFromPackedRefsFile(&refs, f, seen); err != nil {
 		return err
 	}
 
@@ -701,7 +701,7 @@ func (d *DotGit) PackRefs() (err error) {
 
 	w := bufio.NewWriter(tmp)
 	for _, ref := range refs {
-		_, err := w.WriteString(ref.String() + "\n")
+		_, err = w.WriteString(ref.String() + "\n")
 		if err != nil {
 			return err
 		}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit_setref.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit_setref.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/utils/ioutil"
 )
 
-func (d *DotGit) setRef(fileName, content string, old *plumbing.Reference) error {
+func (d *DotGit) setRef(fileName, content string, old *plumbing.Reference) (err error) {
 	// If we are not checking an old ref, just truncate the file.
 	mode := os.O_RDWR | os.O_CREATE
 	if old == nil {

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go
@@ -55,7 +55,7 @@ func (s *ObjectStorage) requireIndex() error {
 	return nil
 }
 
-func (s *ObjectStorage) loadIdxFile(h plumbing.Hash) error {
+func (s *ObjectStorage) loadIdxFile(h plumbing.Hash) (err error) {
 	f, err := s.dir.ObjectPackIdx(h)
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
 }
 
 // SetEncodedObject adds a new object to the storage.
-func (s *ObjectStorage) SetEncodedObject(o plumbing.EncodedObject) (plumbing.Hash, error) {
+func (s *ObjectStorage) SetEncodedObject(o plumbing.EncodedObject) (h plumbing.Hash, err error) {
 	if o.Type() == plumbing.OFSDeltaObject || o.Type() == plumbing.REFDeltaObject {
 		return plumbing.ZeroHash, plumbing.ErrInvalidType
 	}
@@ -113,11 +113,11 @@ func (s *ObjectStorage) SetEncodedObject(o plumbing.EncodedObject) (plumbing.Has
 
 	defer ioutil.CheckClose(or, &err)
 
-	if err := ow.WriteHeader(o.Type(), o.Size()); err != nil {
+	if err = ow.WriteHeader(o.Type(), o.Size()); err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	if _, err := io.Copy(ow, or); err != nil {
+	if _, err = io.Copy(ow, or); err != nil {
 		return plumbing.ZeroHash, err
 	}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/submodule_test.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/submodule_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
@@ -66,6 +67,10 @@ func (s *SubmoduleSuite) TestInit(c *C) {
 }
 
 func (s *SubmoduleSuite) TestUpdate(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	sm, err := s.Worktree.Submodule("basic")
 	c.Assert(err, IsNil)
 
@@ -118,6 +123,10 @@ func (s *SubmoduleSuite) TestUpdateWithNotFetch(c *C) {
 }
 
 func (s *SubmoduleSuite) TestUpdateWithRecursion(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	sm, err := s.Worktree.Submodule("itself")
 	c.Assert(err, IsNil)
 
@@ -134,6 +143,10 @@ func (s *SubmoduleSuite) TestUpdateWithRecursion(c *C) {
 }
 
 func (s *SubmoduleSuite) TestUpdateWithInitAndUpdate(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	sm, err := s.Worktree.Submodule("basic")
 	c.Assert(err, IsNil)
 
@@ -193,6 +206,10 @@ func (s *SubmoduleSuite) TestSubmodulesStatus(c *C) {
 }
 
 func (s *SubmoduleSuite) TestSubmodulesUpdateContext(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	sm, err := s.Worktree.Submodules()
 	c.Assert(err, IsNil)
 

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree.go
@@ -554,6 +554,22 @@ func (w *Worktree) checkoutFileSymlink(f *object.File) (err error) {
 	}
 
 	err = w.Filesystem.Symlink(string(bytes), f.Name)
+
+	// On windows, this might fail.
+	// Follow Git on Windows behavior by writing the link as it is.
+	if err != nil && isSymlinkWindowsNonAdmin(err) {
+		mode, _ := f.Mode.ToOSFileMode()
+
+		to, err := w.Filesystem.OpenFile(f.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
+		if err != nil {
+			return err
+		}
+
+		defer ioutil.CheckClose(to, &err)
+
+		_, err = to.Write(bytes)
+		return err
+	}
 	return
 }
 

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree_darwin.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree_darwin.go
@@ -20,3 +20,7 @@ func init() {
 		}
 	}
 }
+
+func isSymlinkWindowsNonAdmin(err error) bool {
+	return false
+}

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree_linux.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree_linux.go
@@ -20,3 +20,7 @@ func init() {
 		}
 	}
 }
+
+func isSymlinkWindowsNonAdmin(err error) bool {
+	return false
+}

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree_test.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"testing"
 
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -196,6 +197,10 @@ func (s *WorktreeSuite) TestPullProgress(c *C) {
 }
 
 func (s *WorktreeSuite) TestPullProgressWithRecursion(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	path := fixtures.ByTag("submodule").One().Worktree().Root()
 
 	dir, err := ioutil.TempDir("", "plain-clone-submodule")
@@ -613,6 +618,10 @@ func (s *WorktreeSuite) TestCheckoutTag(c *C) {
 }
 
 func (s *WorktreeSuite) TestCheckoutBisect(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	s.testCheckoutBisect(c, "https://github.com/src-d/go-git.git")
 }
 

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree_windows.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree_windows.go
@@ -3,6 +3,7 @@
 package git
 
 import (
+	"os"
 	"syscall"
 	"time"
 
@@ -17,4 +18,18 @@ func init() {
 			e.CreatedAt = time.Unix(seconds, nanoseconds)
 		}
 	}
+}
+
+func isSymlinkWindowsNonAdmin(err error) bool {
+	const ERROR_PRIVILEGE_NOT_HELD syscall.Errno = 1314
+
+	if err != nil {
+		if errLink, ok := err.(*os.LinkError); ok {
+			if errNo, ok := errLink.Err.(syscall.Errno); ok {
+				return errNo == ERROR_PRIVILEGE_NOT_HELD
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
These come with some useful fixes for Borges:

* go-git: Use CheckClose with named returns and fix tests
* go-git: Resolve HEAD if symRefs capability is not supported
* go-billy: Some errors are lost in copyPath