### PR TITLE
[WIP] Add logic to the producer to be able to requeue failed jobs

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -67,7 +67,8 @@ func (s *ConsumerSuite) TestConsumer_StartStop_FailedJob() {
 	require.Error(timeoutChan(done, time.Second*5))
 	require.Equal(1, processed)
 
-	err = s.queue.RepublishBuried()
+	testCondition := func(*queue.Job) bool { return true }
+	err = s.queue.RepublishBuried(testCondition)
 	require.NoError(err)
 
 	require.NoError(timeoutChan(done, time.Second*10))

--- a/worker.go
+++ b/worker.go
@@ -4,7 +4,7 @@ import (
 	"github.com/inconshreveable/log15"
 )
 
-const temporaryError = "temporary"
+const TemporaryError = "temporary"
 
 // Worker is a worker that processes jobs from a channel.
 type Worker struct {
@@ -63,7 +63,7 @@ func (w *Worker) Start() {
 
 			if requeue {
 				job.queueJob.Retries--
-				job.queueJob.ErrorType = temporaryError
+				job.queueJob.ErrorType = TemporaryError
 				job.source.Publish(job.queueJob)
 			}
 


### PR DESCRIPTION
This PR covers the second part from #242, having the producer a flag to requeue jobs from the buried queue.

Right now in the buried queue should be stay only temporary-errors and fatal errors, so temporary errors are requeued and fatal errors are left on the buried queue.

Note that those jobs in the buried queue stayed as pending in the database, so there's no need to change their status when they are requeed.

There are two points to think about:
- Maybe we should drop the fatal errors, tag them with some header, or set them in the database with some special status.
- ~~The `--republish-jobs` flag works as an addition to the producer regular job, so if we republish jobs from the buried queue and we give the producer a list of repositories where there are repositories that they are in the buried queue too, we will have duplicated jobs on the queue. An option could be have a command just to republish jobs.~~

**UPDATE**: after talk with @ajnavarro this functionality should work as a service that only do the requeue task.

What do you think @src-d/data-retrieval?

This PR depends on https://github.com/src-d/framework/pull/40
