### PR TITLE
producer republish command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -338,7 +338,7 @@
     "lock",
     "queue"
   ]
-  revision = "0839a41303d85dd722c2bf23106f01e0f6758115"
+  revision = "88f5399ee0037158edaef606ec57b7037a80c02a"
   source = "https://github.com/src-d/framework.git"
 
 [[projects]]
@@ -461,6 +461,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d5f3e33031a3bdc64909673b95d95bc20bce0f4a4bc695f9fd9a024b2e33a45e"
+  inputs-digest = "166dc6fbcc7d1e8cffdf77291f3176d8f7fa48ad75179fcb650cd7f63359cf15"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,7 +17,7 @@
 
 [[constraint]]
   name = "gopkg.in/src-d/framework.v0"
-  revision = "0839a41303d85dd722c2bf23106f01e0f6758115"
+  revision = "88f5399ee0037158edaef606ec57b7037a80c02a"
   source = "https://github.com/src-d/framework.git"
 
 [[constraint]]

--- a/cli/borges/init.go
+++ b/cli/borges/init.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/inconshreveable/log15"
-
 	"gopkg.in/src-d/core-retrieval.v0/schema"
 	"gopkg.in/src-d/framework.v0/database"
 )
@@ -38,7 +36,7 @@ func (c *initCmd) Execute(args []string) error {
 		return fmt.Errorf("unable to create database schema: %s", err)
 	}
 
-	log15.Info("database was successfully initialized")
+	log.Info("database was successfully initialized")
 	return nil
 }
 

--- a/cli/borges/producer.go
+++ b/cli/borges/producer.go
@@ -105,6 +105,7 @@ func checkPriority(prio uint8) error {
 var producerSubcommands = []ExecutableCommand{
 	mentionsCommand,
 	fileCommand,
+	republishCommand,
 }
 
 func init() {

--- a/cli/borges/republish.go
+++ b/cli/borges/republish.go
@@ -1,0 +1,23 @@
+package main
+
+const (
+	republishCmdName      = "republish"
+	republishCmdShortName = "requeue jobs from buried queues"
+	republishCmdLongDesc  = ""
+)
+
+// republishCommand is a producer subcommand.
+var republishCommand = &republishCmd{producerSubcmd: newProducerSubcmd(
+	republishCmdName,
+	republishCmdShortName,
+	republishCmdLongDesc,
+)}
+
+type republishCmd struct {
+	producerSubcmd
+}
+
+func (c *republishCmd) Execute(args []string) error {
+	log.Warn("Republish command is not implemented yet")
+	return nil
+}

--- a/cli/borges/republish.go
+++ b/cli/borges/republish.go
@@ -1,23 +1,72 @@
 package main
 
+import (
+	"time"
+
+	"github.com/src-d/borges"
+	"gopkg.in/src-d/framework.v0/queue"
+)
+
 const (
 	republishCmdName      = "republish"
-	republishCmdShortName = "requeue jobs from buried queues"
+	republishCmdShortDesc = "requeue jobs from buried queues"
 	republishCmdLongDesc  = ""
 )
 
 // republishCommand is a producer subcommand.
 var republishCommand = &republishCmd{producerSubcmd: newProducerSubcmd(
 	republishCmdName,
-	republishCmdShortName,
+	republishCmdShortDesc,
 	republishCmdLongDesc,
 )}
 
 type republishCmd struct {
 	producerSubcmd
+
+	Time string `long:"time" short:"t" default:"0" description:"elapsed time between republish triggers"`
 }
 
 func (c *republishCmd) Execute(args []string) error {
-	log.Warn("Republish command is not implemented yet")
+	lapse, err := time.ParseDuration(c.Time)
+	if err != nil {
+		return err
+	}
+
+	if err := c.producerSubcmd.init(); err != nil {
+		return err
+	}
+	defer c.broker.Close()
+
+	log.Info("starting republishing jobs...", "time", c.Time)
+
+	log.Debug("republish task triggered ")
+	if err := c.queue.RepublishBuried(republishCondition); err != nil {
+		log.Error("error republishing buried jobs", "error", err)
+	}
+
+	if lapse != 0 {
+		c.runPeriodically(lapse)
+	}
+
+	log.Info("stopping republishing jobs")
 	return nil
+}
+
+func republishCondition(job *queue.Job) bool {
+	// Althoug the job has the temporary error tag, it must be checked
+	// that the retries is equals to zero. The reason for this is that
+	// a job can panic during a retry process, so it can be tagged as
+	// temporary error and a number of retries greater than zero reveals
+	// that fact.
+	return job.ErrorType == borges.TemporaryError && job.Retries == 0
+}
+
+func (c *republishCmd) runPeriodically(lapse time.Duration) {
+	ticker := time.Tick(lapse)
+	for range ticker {
+		log.Debug("republish task triggered ")
+		if err := c.queue.RepublishBuried(republishCondition); err != nil {
+			log.Error("error republishing buried jobs", "error", err)
+		}
+	}
 }

--- a/cli/borges/update.go
+++ b/cli/borges/update.go
@@ -1,0 +1,23 @@
+package main
+
+const (
+	updateCmdName      = "update"
+	updateCmdShortName = "update repositories processed previously"
+	updateCmdLongDesc  = ""
+)
+
+// updateCommand is a producer subcommand.
+var updateCommand = &updateCmd{producerSubcmd: newProducerSubcmd(
+	updateCmdName,
+	updateCmdShortName,
+	updateCmdLongDesc,
+)}
+
+type updateCmd struct {
+	producerSubcmd
+}
+
+func (c *updateCmd) Execute(args []string) error {
+	log.Warn("Update command is not implemented yet")
+	return nil
+}

--- a/vendor/gopkg.in/src-d/framework.v0/.travis.yml
+++ b/vendor/gopkg.in/src-d/framework.v0/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.9
+  - 1.9.x
+  - 1.10.x
   - tip
 
 go_import_path: gopkg.in/src-d/framework.v0

--- a/vendor/gopkg.in/src-d/framework.v0/queue/amqp.go
+++ b/vendor/gopkg.in/src-d/framework.v0/queue/amqp.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,6 +19,7 @@ var (
 	ErrConnectionFailed = errors.NewKind("failed to connect to RabbitMQ: %s")
 	ErrOpenChannel      = errors.NewKind("failed to open a channel: %s")
 	ErrRetrievingHeader = errors.NewKind("error retrieving '%s' header from message %s")
+	ErrRepublishingJobs = errors.NewKind("couldn't republish some jobs : %s")
 )
 
 const (
@@ -288,9 +290,14 @@ func (q *AMQPQueue) PublishDelayed(j *Job, delay time.Duration) error {
 	)
 }
 
-// RepublishBuried will republish in the main queue all the jobs that timed out without Ack
-// or were Rejected with requeue = False.
-func (q *AMQPQueue) RepublishBuried() error {
+type jobErr struct {
+	job *Job
+	err error
+}
+
+// RepublishBuried will republish in the main queue those jobs that timed out without Ack
+// or were Rejected with requeue = False and makes comply return true.
+func (q *AMQPQueue) RepublishBuried(conditions ...RepublishConditionFunc) error {
 	if q.buriedQueue == nil {
 		return fmt.Errorf("buriedQueue is nil, called RepublishBuried on the internal buried queue?")
 	}
@@ -304,6 +311,8 @@ func (q *AMQPQueue) RepublishBuried() error {
 	defer iter.Close()
 
 	retries := 0
+	var notComplying []*Job
+	var errorsPublishing []*jobErr
 	for {
 		j, err := iter.(*AMQPJobIter).nextNonBlocking()
 		if err != nil {
@@ -316,7 +325,7 @@ func (q *AMQPQueue) RepublishBuried() error {
 			// if there is nothing after all the retries (meaning: BuriedQueue is surely
 			// empty or any arriving jobs will have to wait to the next call).
 			if retries > buriedNonBlockingRetries {
-				return nil
+				break
 			}
 
 			time.Sleep(50 * time.Millisecond)
@@ -324,16 +333,45 @@ func (q *AMQPQueue) RepublishBuried() error {
 			continue
 		}
 
+		retries = 0
+
 		if err = j.Ack(); err != nil {
 			return err
 		}
 
-		retries = 0
+		if republishConditions(conditions).comply(j) {
+			if err = q.Publish(j); err != nil {
+				errorsPublishing = append(errorsPublishing, &jobErr{j, err})
+			}
+		} else {
+			notComplying = append(notComplying, j)
 
-		if err = q.Publish(j); err != nil {
+		}
+	}
+
+	for _, job := range notComplying {
+		if err = job.Reject(true); err != nil {
 			return err
 		}
 	}
+
+	return q.handleRepublishErrors(errorsPublishing)
+}
+
+func (q *AMQPQueue) handleRepublishErrors(list []*jobErr) error {
+	if len(list) > 0 {
+		stringErrors := []string{}
+		for _, je := range list {
+			stringErrors = append(stringErrors, je.err.Error())
+			if err := q.buriedQueue.Publish(je.job); err != nil {
+				return err
+			}
+		}
+
+		return ErrRepublishingJobs.New(strings.Join(stringErrors, ": "))
+	}
+
+	return nil
 }
 
 // Transaction executes the given callback inside a transaction.

--- a/vendor/gopkg.in/src-d/framework.v0/queue/common.go
+++ b/vendor/gopkg.in/src-d/framework.v0/queue/common.go
@@ -68,6 +68,25 @@ func NewBroker(uri string) (Broker, error) {
 // TxCallback is a function to be called in a transaction.
 type TxCallback func(q Queue) error
 
+// RepublishConditionFunc is a function used to filter jobs to republish.
+type RepublishConditionFunc func(job *Job) bool
+
+type republishConditions []RepublishConditionFunc
+
+func (c republishConditions) comply(job *Job) bool {
+	if len(c) == 0 {
+		return true
+	}
+
+	for _, condition := range c {
+		if condition(job) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Queue represents a message queue.
 type Queue interface {
 	// Publish publishes the given Job to the queue.
@@ -80,8 +99,9 @@ type Queue interface {
 	// number of undelivered jobs the iterator will allow at any given
 	// time (see the Acknowledger interface).
 	Consume(advertisedWindow int) (JobIter, error)
-	// RepublishBuried republish all jobs in the buried queue to the main one
-	RepublishBuried() error
+	// RepublishBuried republish to the main queue those jobs complying
+	// one of the conditions, leaving the rest of them in the buried queue.
+	RepublishBuried(conditions ...RepublishConditionFunc) error
 }
 
 // JobIter represents an iterator over a set of Jobs.

--- a/vendor/gopkg.in/src-d/framework.v0/queue/memory.go
+++ b/vendor/gopkg.in/src-d/framework.v0/queue/memory.go
@@ -64,9 +64,15 @@ func (q *memoryQueue) PublishDelayed(j *Job, delay time.Duration) error {
 	return nil
 }
 
-func (q *memoryQueue) RepublishBuried() error {
-	for _, j := range q.buriedJobs {
-		q.Publish(j)
+// RepublishBuried implement the Queue interface.
+func (q *memoryQueue) RepublishBuried(conditions ...RepublishConditionFunc) error {
+	for _, job := range q.buriedJobs {
+		if republishConditions(conditions).comply(job) {
+			job.ErrorType = ""
+			if err := q.Publish(job); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/worker.go
+++ b/worker.go
@@ -4,7 +4,7 @@ import (
 	"github.com/inconshreveable/log15"
 )
 
-const temporaryError = "temporary"
+const TemporaryError = "temporary"
 
 // Worker is a worker that processes jobs from a channel.
 type Worker struct {
@@ -63,7 +63,7 @@ func (w *Worker) Start() {
 
 			if requeue {
 				job.queueJob.Retries--
-				job.queueJob.ErrorType = temporaryError
+				job.queueJob.ErrorType = TemporaryError
 				job.source.Publish(job.queueJob)
 			}
 


### PR DESCRIPTION
Added a new subcommand `republish` to the producer command to republish buried jobs:
```
Usage:
  borges [OPTIONS] producer republish [republish-OPTIONS]

Help Options:
  -h, --help               Show this help message

[republish command options]
          --queue=         queue name (default: borges)
          --loglevel=      max log level enabled (default: info)
          --logfile=       path to file where logs will be stored
          --metrics        expose a metrics endpoint using an HTTP server
          --metrics-port=  port to bind metrics to (default: 6062)
          --profiler       start CPU, memory and block profilers
          --profiler-port= port to bind profiler to (default: 6061)
          --priority=      priority used to enqueue jobs, goes from 0 (lowest) to :MAX: (highest)
                           (default: 4)
          --job-retries=   number of times a falied job should be processed again before reject it
                           (default: 5)
      -t, --time=          elapsed time between republish triggers (default: 0)

```

It depends on https://github.com/src-d/framework/pull/40 and https://github.com/src-d/borges/pull/251.

Closes #242 
