### PR TITLE
Avoid log repeated producer next job error

### DIFF
--- a/mentionjobiter.go
+++ b/mentionjobiter.go
@@ -27,10 +27,11 @@ func (i *mentionJobIter) Next() (*Job, error) {
 	}
 
 	mention, j, err := i.getMention()
-
 	if err != nil {
 		if err == queue.ErrAlreadyClosed {
-			i.Close()
+			if err := i.Close(); err != nil {
+				return nil, err
+			}
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Closes #255 

I couldn't reproduce the error, but I think it could come from an unhandled error when a job iterator is closed.

I added some logic to avoid log the same error again and again.

Signed-off-by: Manuel Carmona <manu.carmona90@gmail.com>