### PR TITLE
consumer: support graceful shutdown

### DIFF
--- a/archiver_test.go
+++ b/archiver_test.go
@@ -105,7 +105,7 @@ func (s *ArchiverSuite) TestCheckTimeout() {
 			var hash model.SHA1
 			err = withInProcRepository(hash, r, func(url string) error {
 				rid = s.newRepositoryModel(url)
-				return s.a.Do(&Job{RepositoryID: uuid.UUID(rid)})
+				return s.a.Do(context.TODO(), &Job{RepositoryID: uuid.UUID(rid)})
 			})
 
 			require.Error(err)
@@ -165,7 +165,7 @@ func (s *ArchiverSuite) TestFixtures() {
 			// emulate initial status of a repository
 			err = withInProcRepository(hash, or, func(url string) error {
 				rid = s.newRepositoryModel(url)
-				return s.a.Do(&Job{RepositoryID: uuid.UUID(rid)})
+				return s.a.Do(context.TODO(), &Job{RepositoryID: uuid.UUID(rid)})
 			})
 			require.NoError(err)
 
@@ -180,7 +180,7 @@ func (s *ArchiverSuite) TestFixtures() {
 				updated, err := s.rawStore.Save(mr)
 				require.NoError(err)
 				require.True(updated, err)
-				return s.a.Do(&Job{RepositoryID: uuid.UUID(mr.ID)})
+				return s.a.Do(context.TODO(), &Job{RepositoryID: uuid.UUID(mr.ID)})
 			})
 			require.NoError(err)
 
@@ -216,7 +216,7 @@ func (s *ArchiverSuite) TestFixtures() {
 
 func (s *ArchiverSuite) TestNotExistingRepository() {
 	rid := s.newRepositoryModel("file:///this/repository/does/not/exists")
-	err := s.a.Do(&Job{RepositoryID: uuid.UUID(rid)})
+	err := s.a.Do(context.TODO(), &Job{RepositoryID: uuid.UUID(rid)})
 	s.NoError(err)
 
 	mr, err := s.rawStore.FindOne(model.NewRepositoryQuery().FindByID(rid))
@@ -227,7 +227,7 @@ func (s *ArchiverSuite) TestNotExistingRepository() {
 
 func (s *ArchiverSuite) TestPrivateRepository() {
 	rid := s.newRepositoryModel("https://github.com/src-d/company")
-	err := s.a.Do(&Job{RepositoryID: uuid.UUID(rid)})
+	err := s.a.Do(context.TODO(), &Job{RepositoryID: uuid.UUID(rid)})
 	s.NoError(err)
 
 	mr, err := s.rawStore.FindOne(model.NewRepositoryQuery().FindByID(rid))
@@ -244,7 +244,7 @@ func (s *ArchiverSuite) TestProcessingRepository() {
 	_, err = s.rawStore.Save(repo)
 	s.NoError(err)
 
-	err = s.a.Do(&Job{RepositoryID: uuid.UUID(rid)})
+	err = s.a.Do(context.TODO(), &Job{RepositoryID: uuid.UUID(rid)})
 	s.True(ErrAlreadyFetching.Is(err))
 
 	mr, err := s.rawStore.FindOne(model.NewRepositoryQuery().FindByID(rid))

--- a/consumer.go
+++ b/consumer.go
@@ -33,7 +33,7 @@ func NewConsumer(queue queue.Queue, pool *WorkerPool) *Consumer {
 }
 
 // Start initializes the consumer and starts it, blocking until it is stopped.
-func (c *Consumer) Start() {
+func (c *Consumer) Start() error {
 	c.m.Lock()
 	c.quit = make(chan struct{})
 	c.done = make(chan struct{})
@@ -44,7 +44,7 @@ func (c *Consumer) Start() {
 	for {
 		select {
 		case <-c.quit:
-			return
+			return c.WorkerPool.Stop()
 		default:
 			if err := c.consumeQueue(c.Queue); err != nil {
 				c.notifyQueueError(err)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1,6 +1,7 @@
 package borges
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -35,7 +36,10 @@ type ConsumerSuite struct {
 }
 
 func (s *ConsumerSuite) newConsumer() *Consumer {
-	wp := NewWorkerPool(logrus.NewEntry(logrus.StandardLogger()), func(*logrus.Entry, *Job) error { return nil })
+	wp := NewWorkerPool(
+		logrus.NewEntry(logrus.StandardLogger()),
+		func(context.Context, *logrus.Entry, *Job) error { return nil },
+	)
 	return NewConsumer(s.queue, wp)
 }
 
@@ -52,7 +56,7 @@ func (s *ConsumerSuite) TestConsumer_StartStop_FailedJob() {
 
 	processed := 0
 	done := make(chan struct{}, 1)
-	c.WorkerPool.do = func(log *logrus.Entry, j *Job) error {
+	c.WorkerPool.do = func(ctx context.Context, log *logrus.Entry, j *Job) error {
 		defer func() { done <- struct{}{} }()
 		processed++
 		if processed == 2 {
@@ -104,7 +108,7 @@ func (s *ConsumerSuite) TestConsumer_StartStop() {
 
 	processed := 0
 	done := make(chan struct{}, 1)
-	c.WorkerPool.do = func(*logrus.Entry, *Job) error {
+	c.WorkerPool.do = func(context.Context, *logrus.Entry, *Job) error {
 		processed++
 		if processed > 1 {
 			assert.Fail("too many jobs processed")

--- a/executor_test.go
+++ b/executor_test.go
@@ -1,6 +1,7 @@
 package borges
 
 import (
+	"context"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -52,7 +53,7 @@ func (s *ExecutorSuite) assertRepo(endpoint string, job *Job) {
 
 func (s *ExecutorSuite) runExecutor(repos ...string) ([]*Job, error) {
 	require := s.Require()
-	q, err := queue.NewMemoryBroker().Queue("jobs")
+	q, err := queue.NewMemoryBroker().Queue(kallax.NewULID().String())
 	require.NoError(err)
 
 	r := ioutil.NopCloser(strings.NewReader(strings.Join(repos, "\n")))
@@ -60,8 +61,7 @@ func (s *ExecutorSuite) runExecutor(repos ...string) ([]*Job, error) {
 	var jobs []*Job
 
 	log := logrus.NewEntry(logrus.StandardLogger())
-
-	wp := NewWorkerPool(log, func(log *logrus.Entry, j *Job) error {
+	wp := NewWorkerPool(log, func(ctx context.Context, log *logrus.Entry, j *Job) error {
 		jobs = append(jobs, j)
 		return nil
 	})

--- a/worker.go
+++ b/worker.go
@@ -1,6 +1,8 @@
 package borges
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -9,9 +11,10 @@ const TemporaryError = "temporary"
 // Worker is a worker that processes jobs from a channel.
 type Worker struct {
 	logentry   *logrus.Entry
-	do         func(*logrus.Entry, *Job) error
+	do         WorkerFunc
 	jobChannel chan *WorkerJob
-	quit       chan struct{}
+	quit       chan bool
+	finished   chan struct{}
 	running    bool
 }
 
@@ -19,12 +22,13 @@ type Worker struct {
 // will be passed to the processing function on every call. The second parameter
 // is the processing function itself that will be called for every job. The
 // third parameter is a channel that the worker will consume jobs from.
-func NewWorker(logentry *logrus.Entry, do func(*logrus.Entry, *Job) error, ch chan *WorkerJob) *Worker {
+func NewWorker(logentry *logrus.Entry, do WorkerFunc, ch chan *WorkerJob) *Worker {
 	return &Worker{
 		logentry:   logentry,
 		do:         do,
 		jobChannel: ch,
-		quit:       make(chan struct{}),
+		quit:       make(chan bool),
+		finished:   make(chan struct{}),
 	}
 }
 
@@ -32,61 +36,83 @@ func NewWorker(logentry *logrus.Entry, do func(*logrus.Entry, *Job) error, ch ch
 // until the worker is stopped or the channel is closed.
 func (w *Worker) Start() {
 	w.running = true
-	defer func() { w.running = false }()
+	defer func() {
+		w.running = false
+		close(w.finished)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	log := w.logentry
 	log.Info("starting")
 	for {
 		select {
+		case <-w.quit:
+			return
 		case job, ok := <-w.jobChannel:
 			if !ok {
 				return
 			}
 
-			var requeue bool
-			if err := w.do(log, job.Job); err != nil {
-				// when a previous job which failed with a temporary error
-				// panics, it's sent to the buried queue without the retries
-				// header or with this header set to a value greater than zero.
-				if ErrFatal.Is(err) || job.queueJob.Retries == 0 {
-					if err := job.queueJob.Reject(false); err != nil {
-						log.WithField("error", err).Error("error rejecting job")
+			var done = make(chan struct{})
+
+			go func() {
+				defer close(done)
+
+				var requeue bool
+				if err := w.do(ctx, log, job.Job); err != nil {
+					// when a previous job which failed with a temporary error
+					// panics, it's sent to the buried queue without the retries
+					// header or with this header set to a value greater than zero.
+					if ErrFatal.Is(err) || job.queueJob.Retries == 0 {
+						if err := job.queueJob.Reject(false); err != nil {
+							log.WithField("error", err).Error("error rejecting job")
+						}
+
+						log.WithField("error", err).Error("error on job")
+						return
 					}
 
-					log.WithField("error", err).Error("error on job")
-					continue
+					requeue = true
 				}
 
-				requeue = true
-			}
+				if requeue {
+					job.queueJob.Retries--
+					job.queueJob.ErrorType = TemporaryError
+					if err := job.source.Publish(job.queueJob); err != nil {
+						log.Error("error publishing job back to the main queue", "error", err)
+						if err := job.queueJob.Reject(false); err != nil {
+							log.Error("error rejecting job", "error", err)
+						}
 
-			if requeue {
-				job.queueJob.Retries--
-				job.queueJob.ErrorType = TemporaryError
-				if err := job.source.Publish(job.queueJob); err != nil {
-					log.Error("error publishing job back to the main queue", "error", err)
-					if err := job.queueJob.Reject(false); err != nil {
-						log.Error("error rejecting job", "error", err)
+						return
 					}
-
-					continue
 				}
-			}
 
-			if err := job.queueJob.Ack(); err != nil {
-				log.WithField("error", err).Error("error acking job")
-			}
+				if err := job.queueJob.Ack(); err != nil {
+					log.WithField("error", err).Error("error acking job")
+				}
+			}()
 
-		case <-w.quit:
-			return
+			select {
+			case now := <-w.quit:
+				if now {
+					return
+				}
+
+				<-done
+				return
+			case <-done:
+			}
 		}
 	}
 }
 
-// Stop stops the worker. It blocks until it is actually stopped. If it is
-// currently processing a job, it will finish before stopping.
-func (w *Worker) Stop() {
-	w.quit <- struct{}{}
+// Stop stops the worker, but does not wait until it
+func (w *Worker) Stop(immediate bool) {
+	w.quit <- immediate
+	<-w.finished
 }
 
 // IsRunning returns true if the worker is running.


### PR DESCRIPTION
Implements some of the things in #263, but it's still missing the `Copy` thing as there's still discussion around that in https://github.com/src-d/core-retrieval/issues/57 and https://github.com/src-d/core-retrieval/issues/58.

For now this implements cancellation of the clones when a SIGTERM is received in the program and stops the consumer so more jobs can't be taken.