### PR TITLE
producer: check repeated errors by string

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -84,7 +84,7 @@ func (p *Producer) start() {
 		if err != nil {
 			if nextJobSameErr < nextJobErrMaxPrints {
 				log.WithField("error", err).Error("error obtaining next job")
-				if lastNextJobErr == nil || err == lastNextJobErr {
+				if lastNextJobErr == nil || err.Error() == lastNextJobErr.Error() {
 					nextJobSameErr++
 				} else {
 					nextJobSameErr = 0


### PR DESCRIPTION
I just realized that some libraries return the same instance for the same error and others libraries create a new instance for the same error, so the comparison must be done by the string error.

We have an example of this in [src-d/framework](https://github.com/src-d/framework/), where we mix errors defined with the standard "errors" library and errors defined with [src-d/go-errors](https://github.com/src-d/go-errors).

Those errors defined with the standard library always returns the same instance, while errors defined with `src-d/go-errors` return a new instance each time.

standard lib:
https://github.com/src-d/framework/blob/master/queue/common.go

go-errors lib:
https://github.com/src-d/framework/blob/master/queue/amqp.go

Signed-off-by: Manuel Carmona <manu.carmona90@gmail.com>