### PR TITLE
(,cli/borges): copy reference time, make sure Stop is not called twice

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -174,7 +174,8 @@ func (a *Archiver) do(ctx context.Context, log *logrus.Entry, j *Job) (err error
 	gr, err := a.TemporaryCloner.Clone(
 		ctx,
 		j.RepositoryID.String(),
-		endpoint)
+		endpoint,
+	)
 	if err != nil {
 		var finalErr error
 		if err != transport.ErrEmptyUploadPackRequest {
@@ -278,10 +279,15 @@ func selectEndpoint(endpoints []string) (string, error) {
 	return endpoints[0], nil
 }
 
-func (a *Archiver) pushChangesToRootedRepositories(ctx context.Context, ctxLog *logrus.Entry,
-	j *Job, r *model.Repository, tr TemporaryRepository, changes Changes,
-	now time.Time) error {
-
+func (a *Archiver) pushChangesToRootedRepositories(
+	ctx context.Context,
+	ctxLog *logrus.Entry,
+	j *Job,
+	r *model.Repository,
+	tr TemporaryRepository,
+	changes Changes,
+	now time.Time,
+) error {
 	var failedInits []model.SHA1
 	for ic, cs := range changes {
 		log := ctxLog.WithField("root", ic.String())
@@ -307,6 +313,7 @@ func (a *Archiver) pushChangesToRootedRepositories(ctx context.Context, ctxLog *
 		log.Debug("push changes to rooted repository finished")
 
 		log.Debug("update repository references started")
+
 		r.References = updateRepositoryReferences(r.References, cs, ic)
 		for _, ref := range r.References {
 			ref.Repository = r

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -197,6 +197,10 @@ func (s *ArchiverSuite) TestFixtures() {
 			// check references in database
 			mr, err := s.rawStore.FindOne(model.NewRepositoryQuery().FindByID(rid).WithReferences(nil))
 			require.NoError(err)
+			if len(mr.References) > 0 {
+				require.NotNil(mr.LastCommitAt)
+				require.NotEqual(new(time.Time), mr.LastCommitAt)
+			}
 			checkReferencesInDB(t, mr, ct.NewReferences)
 
 			// check references in siva files

--- a/changes.go
+++ b/changes.go
@@ -111,8 +111,8 @@ func addToChangesDfferenceBetweenOldAndNewRefs(
 	now time.Time,
 	c Changes,
 	newRef *model.Reference,
-	oldRefs map[string]*model.Reference) error {
-
+	oldRefs map[string]*model.Reference,
+) error {
 	oldRef, ok := oldRefs[newRef.Name]
 
 	// If we don't have the reference or the init commit has changed,
@@ -132,6 +132,7 @@ func addToChangesDfferenceBetweenOldAndNewRefs(
 			CreatedAt: createdAt,
 			UpdatedAt: now,
 		}
+		newReference.Time = newRef.Time
 		c.Add(newReference)
 
 		return nil

--- a/cli/borges/consumer.go
+++ b/cli/borges/consumer.go
@@ -72,13 +72,13 @@ func (c *consumerCmd) Execute(args []string) error {
 			log.Info("signal received, stopping...")
 			ac.Stop()
 		case <-done:
+			ac.Stop()
 		}
 	}()
 	signal.Notify(term, syscall.SIGTERM, os.Interrupt)
 
 	err = ac.Start()
 	close(done)
-	ac.Stop()
 
 	return err
 }

--- a/git.go
+++ b/git.go
@@ -69,7 +69,7 @@ func (r gitReferencer) References() ([]*model.Reference, error) {
 	var refs []*model.Reference
 	var seenRoots = make(map[plumbing.Hash][]model.SHA1)
 	return refs, iter.ForEach(func(ref *plumbing.Reference) error {
-		//TODO: add tags support
+		// TODO: add tags support
 		if ref.Type() != plumbing.HashReference || ref.Name().IsRemote() {
 			return nil
 		}


### PR DESCRIPTION
Fixes #273

Some formatting I came across while debugging fixed as well.

Also fixes a problem where Consumer.Stop could be called twice under when a SIGINT signal is sent.