### PR TITLE
(,cli/borges): copy reference time, make sure Stop is not called twice

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -288,8 +288,12 @@ func selectEndpoint(endpoints []string) (string, error) {
 }
 
 func (a *Archiver) pushChangesToRootedRepositories(
-	ctx context.Context, logger log.Logger,
-	j *Job, r *model.Repository, tr TemporaryRepository, changes Changes,
+	ctx context.Context,
+	logger log.Logger,
+	j *Job,
+	r *model.Repository,
+	tr TemporaryRepository,
+	changes Changes,
 	now *time.Time,
 ) error {
 	var failedInits []model.SHA1

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -196,6 +196,10 @@ func (s *ArchiverSuite) TestFixtures() {
 			// check references in database
 			mr, err := s.rawStore.FindOne(model.NewRepositoryQuery().FindByID(rid).WithReferences(nil))
 			require.NoError(err)
+			if len(mr.References) > 0 {
+				require.NotNil(mr.LastCommitAt)
+				require.NotEqual(new(time.Time), mr.LastCommitAt)
+			}
 			checkReferencesInDB(t, mr, ct.NewReferences)
 
 			// check references in siva files

--- a/changes.go
+++ b/changes.go
@@ -111,8 +111,8 @@ func addToChangesDfferenceBetweenOldAndNewRefs(
 	now time.Time,
 	c Changes,
 	newRef *model.Reference,
-	oldRefs map[string]*model.Reference) error {
-
+	oldRefs map[string]*model.Reference,
+) error {
 	oldRef, ok := oldRefs[newRef.Name]
 
 	// If we don't have the reference or the init commit has changed,
@@ -132,6 +132,7 @@ func addToChangesDfferenceBetweenOldAndNewRefs(
 			CreatedAt: createdAt,
 			UpdatedAt: now,
 		}
+		newReference.Time = newRef.Time
 		c.Add(newReference)
 
 		return nil

--- a/cli/borges/consumer.go
+++ b/cli/borges/consumer.go
@@ -78,13 +78,13 @@ func (c *consumerCmd) Execute(args []string) error {
 			log.Infof("signal received, stopping...")
 			ac.Stop()
 		case <-done:
+			ac.Stop()
 		}
 	}()
 	signal.Notify(term, syscall.SIGTERM, os.Interrupt)
 
 	err = ac.Start()
 	close(done)
-	ac.Stop()
 
 	return err
 }

--- a/git.go
+++ b/git.go
@@ -70,7 +70,7 @@ func (r gitReferencer) References() ([]*model.Reference, error) {
 	var seenRoots = make(map[plumbing.Hash][]model.SHA1)
 
 	err = iter.ForEach(func(ref *plumbing.Reference) error {
-		//TODO: add tags support
+		// TODO: add tags support
 		if ref.Type() != plumbing.HashReference || ref.Name().IsRemote() {
 			return nil
 		}


### PR DESCRIPTION
*This is a rebase of #276*

Fixes #273

Also fixes a problem where Consumer.Stop could be called twice under when a SIGINT signal is sent.
