### PR TITLE
Use go 1.10 to build binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.9.x
   - 1.10.x
   - tip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_deploy:
   - make packages
 
 deploy:
+  go: 1.10.x
   provider: releases
   api_key: $GITHUB_TOKEN
   file_glob: true


### PR DESCRIPTION
Use go 1.10 to generate binaries.

**Do not merge until just before a new release is done so all other 0.16.x releases use the same go version.**