### PR TITLE
Add order by to force the use of index.

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -76,7 +76,8 @@ func (s *DatabaseStore) GetByEndpoints(
 			WithReferences(nil).
 			Where(kallax.And(kallax.ArrayOverlap(
 				model.Schema.Repository.Endpoints, q...,
-			))),
+			))).
+			Order(kallax.Asc(model.Schema.Repository.Endpoints)),
 	)
 	if err != nil {
 		return nil, err

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -54,9 +54,20 @@ func (s *DatabaseSuite) TestGetByEndpoints() {
 	result, err := s.store.GetByEndpoints("bar", "baz")
 	require.Len(result, 3)
 	require.NoError(err)
-	require.Equal(repos[1].ID, result[0].ID)
-	require.Equal(repos[2].ID, result[1].ID)
-	require.Equal(repos[3].ID, result[2].ID)
+
+	expected := []kallax.ULID{
+		repos[1].ID,
+		repos[2].ID,
+		repos[3].ID,
+	}
+
+	got := []kallax.ULID{
+		result[0].ID,
+		result[1].ID,
+		result[2].ID,
+	}
+
+	require.ElementsMatch(expected, got)
 
 	result, err = s.store.GetByEndpoints("notfound")
 	require.Len(result, 0)


### PR DESCRIPTION
Batching adds a limit that disables the index and makes the queries much slower. Order forces the use of the index.

Fixes src-d/backlog#1270
