### PR TITLE
borges: set default worker number to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ To launch a consumer instance from the command line with default configuration:
 
     borges consumer
 
-You can select the number of workers to use, by default it uses 8:
+You can select the number of workers to use, by default it uses 1:
 
-    borges consumer --workers=20
+    borges consumer --workers=4
 
 A command you could use to run it could be:
 
@@ -136,7 +136,7 @@ A command you could use to run it could be:
 $ CONFIG_TEMP_DIR="/borges/tmp"  \
 CONFIG_ROOT_REPOSITORIES_DIR="/borges/root-repositories"  \
 LOG_LEVEL=debug \
-borges consumer --workers=20
+borges consumer --workers=4
 ```
 
 For more details, use `borges consumer -h`

--- a/cli/borges/consumer.go
+++ b/cli/borges/consumer.go
@@ -31,7 +31,7 @@ var consumerCommand = &consumerCmd{command: newCommand(
 type consumerCmd struct {
 	command
 	Locking string `long:"locking" env:"CONFIG_LOCKING" default:"local:" description:"locking service configuration"`
-	Workers int    `long:"workers" default:"8" description:"number of workers"`
+	Workers int    `long:"workers" default:"1" description:"number of workers"`
 	Timeout string `long:"timeout" default:"10h" description:"deadline to process a job"`
 }
 

--- a/cli/borges/packer.go
+++ b/cli/borges/packer.go
@@ -34,7 +34,7 @@ type packerCmd struct {
 	File      string `long:"file" short:"f" required:"true" description:"file with the repositories to pack (one per line)"`
 	OutputDir string `long:"to" default:"repositories" description:"path to store the packed siva files"`
 	Timeout   string `long:"timeout" default:"30m" description:"time to wait to consider a job failed"`
-	Workers   int    `long:"workers" default:"0" description:"number of workers to use, defaults to number of available processors"`
+	Workers   int    `long:"workers" default:"1" description:"number of workers to use, 0 means the same number as processors"`
 }
 
 func (c *packerCmd) Execute(args []string) error {


### PR DESCRIPTION
Repository download can be memory hungry and cause OOMs if done concurrently. This change makes the default more conservative with only one worker. Also the packer command now uses one worker by default. This command is usually run in a workstation and can cause problems.

Fixes #323