### PR TITLE
makefile: disable cgo building borges binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 PROJECT = borges
 COMMANDS = cli/borges
 
+GO_BUILD_ENV = CGO_ENABLED=0
 GO_TAGS = norwfs
 
 # Including ci Makefile


### PR DESCRIPTION
It makes docker images error as it generates a dynamic binary.
