### PR TITLE
travis: use ci godep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ before_script:
 
 script:
   - make test-coverage
-  - go get github.com/golang/dep/cmd/dep
-  - dep ensure
-  - make no-changes-in-commit
+  - make godep no-changes-in-commit
 
 before_deploy:
   - make packages


### PR DESCRIPTION
It downloads the latest release instead of master. Fixes problems when it's in development and the format of `Gopkg.lock` changes.

Fixes #315 