### PR TITLE
Trim spaces from urls when running from file

### DIFF
--- a/linejobiter.go
+++ b/linejobiter.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 	"path"
 	"path/filepath"
 )
@@ -35,7 +36,7 @@ func (i *lineJobIter) Next() (*Job, error) {
 		return nil, io.EOF
 	}
 
-	line := string(i.Bytes())
+	line := strings.TrimSpace(string(i.Bytes()))
 	// check if the line is an absolute path to a directory.
 	// If the path is a directory we can look for the .git directory to try
 	// to guess if it's a git repo or a bare repo.


### PR DESCRIPTION
Ensure that white spaces is trimmed from the URLs read from a file. ~Please note that in my tests there is an issue where urls read from a text file have an space added to the start (this space is NOT in the text file) so there is another issue that you can add from the friction log or I could add it separately.~

Update: there is no issue, the file really had spaces at the front of each URL but Vim wasn't jumping to it when going to the next line because of my settings, I'm an idiot, still this PR has merit to make the parsing of URLs more robust.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>