### PR TITLE
Two small doc improvements

### DIFF
--- a/docs/using-borges/getting-started.md
+++ b/docs/using-borges/getting-started.md
@@ -22,7 +22,7 @@ docker pull rabbitmq:3-management
 Start RabbitMQ and PostgreSQL (you can skip this step if you already have that setup for [rovers](https://github.com/src-d/rovers)).
 
 ```
-docker run -d --name postgres -e POSTGRES_PASSWORD=testing -p 5432:5432 -e POSTGRES_USER=testing postgres
+docker run -d --name postgres -e POSTGRES_PASSWORD=testing -p 5432:5432 -e POSTGRES_USER=testing postgres:9.6-alpine
 docker run -d --hostname rabbitmq --name rabbitmq -p 8081:15672 -p 5672:5672 rabbitmq:3-management
 ```
 

--- a/docs/using-borges/key-concepts.md
+++ b/docs/using-borges/key-concepts.md
@@ -6,7 +6,7 @@ A standalone process that reads repository URLs (from RabbitMQ or file) and sche
 
 ## Borges consumer
 
-A standalone process that takes URLs from RabbitMQ, clones remote repository and pushes it to the appropriate *Rooted Repository* in the storage (local filesystem or HDFS).
+A standalone process that takes URLs from RabbitMQ, clones remote repository and pushes it to the appropriate *Rooted Repository* in the storage (local filesystem or HDFS). Downloaded repositories will be packed into siva files so you don't need to run Borges packer (described below) on them.
 
 ## Borges packer
 


### PR DESCRIPTION
- Set the docker tag for postgress in one of the example commands to the same one used above with `docker pull`, to avoid downloading postgres twice (once for the tag, once for `latest` which is the untagged default).

- Indicate the borges consumer will pack repos with siva.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>