### PR TITLE
docs: update doc to new version

### DIFF
--- a/docs/using-borges/configuration.md
+++ b/docs/using-borges/configuration.md
@@ -72,8 +72,8 @@ borges producer --republish-buried
 So a possible command to launch the producer could be:
 
 ```bash
-$ CONFIG_DATABASE="postgres://user:password@localhost/borges-db" \
-CONFIG_BROKER="amqp://guest:guest@rabbitmq:5672" \
+$ BORGES_DATABASE="postgres://user:password@localhost/borges-db" \
+BORGES_BROKER="amqp://guest:guest@rabbitmq:5672" \
 LOG_LEVEL=debug \
 borges producer mentions
 ```
@@ -103,8 +103,8 @@ You can select the number of workers to use, by default it uses 1:
 A command you could use to run it could be:
 
 ```bash
-$ CONFIG_TEMP_DIR="/borges/tmp"  \
-CONFIG_ROOT_REPOSITORIES_DIR="/borges/root-repositories"  \
+$ BORGES_TEMP_DIR="/borges/tmp"  \
+BORGES_ROOT_REPOSITORIES_DIR="/borges/root-repositories"  \
 LOG_LEVEL=debug \
 borges consumer --workers=4
 ```

--- a/docs/using-borges/development.md
+++ b/docs/using-borges/development.md
@@ -24,7 +24,7 @@ Borges has 2 runtime dependencies and has tests that depend on them:
 
     Consumers and Producers interact through a Queue. You can run one in Docker with the following command:
     ```
-    docker run -d --hostname rabbit --name rabbit -p 8080:15672 -p 5672:5672 rabbitmq:3-management
+    docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 rabbitmq:3-management
     ```
     Note: a hostname needs to be provided, due to the fact that RabbitMQ stores data according to the host name
 

--- a/docs/using-borges/getting-started.md
+++ b/docs/using-borges/getting-started.md
@@ -23,7 +23,7 @@ Start RabbitMQ and PostgreSQL (you can skip this step if you already have that s
 
 ```
 docker run -d --name postgres -e POSTGRES_PASSWORD=testing -p 5432:5432 -e POSTGRES_USER=testing postgres:9.6-alpine
-docker run -d --hostname rabbitmq --name rabbitmq -p 8081:15672 -p 5672:5672 rabbitmq:3-management
+docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 rabbitmq:3-management
 ```
 
 Now, you can start the borges consumer, the component that will be listening for jobs and processing repositories.


### PR DESCRIPTION
* CONFIG_ -> BORGES_
* http port for rabbitmq to 15672
* use the same name for rabbitmq container in development and getting-started guides
