### PR TITLE
borges: check if siva file is empty when it shouldn't

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
 
 script:
   - make test-coverage
+  - make codecov
   - make godep no-changes-in-commit
 
 before_deploy:

--- a/common.go
+++ b/common.go
@@ -30,6 +30,11 @@ type RepositoryStore interface {
 	// GetByEndpoints returns the Repositories that have common endpoints with the
 	// list of endpoints passed.
 	GetByEndpoints(endpoints ...string) ([]*model.Repository, error)
+	// GetRefsByInit returns the References that have the provided Init commit.
+	GetRefsByInit(init model.SHA1) ([]*model.Reference, error)
+	// InitHasRefs returns true if there is at least one reference with
+	// the provided initial commit.
+	InitHasRefs(init model.SHA1) (bool, error)
 	// SetStatus changes the status of the given repository.
 	SetStatus(repo *model.Repository, status model.FetchStatus) error
 	// SetEndpoints updates the endpoints of the repository.


### PR DESCRIPTION
If there are mentions to the init commit in any reference it checks that
the siva is not empty (contains at least one commit).

To do this two new functions are added to `RepositoryStore` interface:

* `GetRefsByInit`: Gets all references that have the provided init commit.
Still not used but will be needed soon to fix problems with missing or
broken siva files.
* `InitHasRefs`: Returns true if there's a reference with an specific init
commit. Similar to `GetRefsByInit` but faster because it only check that
at least one reference has it and does not retrieve repository data.

Note: we need an index in `Reference.Init`

Fixes: #365