### PR TITLE
Fix staticcheck problems and panic recovery

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -436,7 +436,7 @@ func (a *Archiver) pushChangesToRootedRepository(ctx context.Context, logger log
 		"rooted-repository": ic.String(),
 	})
 
-	sivaCpFromDuration := time.Now().Sub(rootedRepoCpStart)
+	sivaCpFromDuration := time.Since(rootedRepoCpStart)
 	logger.With(log.Fields{
 		"duration": sivaCpFromDuration,
 	}).Debugf("copy siva file from FS")
@@ -466,14 +466,14 @@ func (a *Archiver) pushChangesToRootedRepository(ctx context.Context, logger log
 		refspecs := a.changesToPushRefSpec(r.ID, changes)
 		pushStart := time.Now()
 		if err := tr.Push(ctx, url, refspecs); err != nil {
-			onlyPushDurationSec := int64(time.Now().Sub(pushStart) / time.Second)
+			onlyPushDurationSec := int64(time.Since(pushStart) / time.Second)
 			logger.With(log.Fields{
 				"refs":     refspecs,
 				"duration": onlyPushDurationSec,
 			}).Errorf(err, "error pushing one change for")
 			return err
 		}
-		onlyPushDurationSec := int64(time.Now().Sub(pushStart) / time.Second)
+		onlyPushDurationSec := int64(time.Since(pushStart) / time.Second)
 		logger.With(log.Fields{
 			"duration": onlyPushDurationSec,
 		}).Debugf("one change pushed")
@@ -482,13 +482,13 @@ func (a *Archiver) pushChangesToRootedRepository(ctx context.Context, logger log
 		err = a.commitTxWithRetries(ctx, logger, ic, tx, maxRetries)
 		if err != nil {
 			logger.With(log.Fields{
-				"duration": time.Now().Sub(rootedRepoCpStart),
+				"duration": time.Since(rootedRepoCpStart),
 			}).Errorf(err, "could not copy siva file to FS")
 			return err
 		}
 
 		logger.With(log.Fields{
-			"duration": time.Now().Sub(rootedRepoCpStart),
+			"duration": time.Since(rootedRepoCpStart),
 		}).Debugf("copy siva file to FS")
 
 		return nil

--- a/archiver.go
+++ b/archiver.go
@@ -131,7 +131,7 @@ func (a *Archiver) do(
 	}
 
 	defer a.reportMetrics(r, now)
-	defer a.recoverDo(logger, r, &now, err)
+	defer a.recoverDo(logger, r, &now, &err)
 	defer func() {
 		logger.With(log.Fields{"status": r.Status}).Debugf("repository processed")
 	}()
@@ -259,18 +259,17 @@ func (a *Archiver) reportMetrics(r *model.Repository, now time.Time) {
 	}
 }
 
-func (a *Archiver) recoverDo(logger log.Logger, r *model.Repository, now *time.Time, err error) {
-	return
+func (a *Archiver) recoverDo(logger log.Logger, r *model.Repository, now *time.Time, err *error) {
 	rcv := recover()
 	if rcv == nil {
 		return
 	}
 
-	logger.Errorf(err, "panic while processing repository")
+	logger.Errorf(*err, "panic while processing repository")
 
 	r.FetchErrorAt = now
 	a.updateFailed(r, model.Pending)
-	err = ErrFatal.New(rcv, debug.Stack())
+	*err = ErrFatal.New(rcv, debug.Stack())
 }
 
 func (a *Archiver) isProcessableRepository(r *model.Repository, now *time.Time) error {

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -203,10 +203,10 @@ func (s *ArchiverSuite) TestFixtures() {
 			require := require.New(t)
 			var hash model.SHA1
 
-			or, err := ct.OldRepository()
+			or, _ := ct.OldRepository()
 			var rid kallax.ULID
 			// emulate initial status of a repository
-			err = withInProcRepository(hash, or, func(url string) error {
+			err := withInProcRepository(hash, or, func(url string) error {
 				rid = s.newRepositoryModel(url)
 				return s.a.Do(context.TODO(), &Job{RepositoryID: uuid.UUID(rid)})
 			})

--- a/changes.go
+++ b/changes.go
@@ -17,9 +17,9 @@ type Action string
 
 const (
 	Create  Action = "create"
-	Update         = "update"
-	Delete         = "delete"
-	Invalid        = "invalid"
+	Update  Action = "update"
+	Delete  Action = "delete"
+	Invalid Action = "invalid"
 )
 
 // Command is the way to represent a change into a reference. It could be:

--- a/cli/borges-tool/queue.go
+++ b/cli/borges-tool/queue.go
@@ -9,7 +9,6 @@ import (
 	bcli "github.com/src-d/borges/cli"
 	"github.com/src-d/borges/tool"
 
-	billy "gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-cli.v0"
 	queue "gopkg.in/src-d/go-queue.v1"
 	_ "gopkg.in/src-d/go-queue.v1/amqp"
@@ -24,7 +23,6 @@ type queueCmd struct {
 	bcli.DatabaseOpts
 	bcli.QueueOpts
 
-	fs   billy.Basic
 	db   *tool.Database
 	r    *tool.Repository
 	q    queue.Queue

--- a/cli/borges/producer.go
+++ b/cli/borges/producer.go
@@ -93,7 +93,7 @@ func setPrioritySettings(c *flags.Command) {
 
 func checkPriority(prio uint8) error {
 	if prio > uint8(queue.PriorityUrgent) {
-		return fmt.Errorf("Priority must be between 0 and %d", queue.PriorityUrgent)
+		return fmt.Errorf("priority must be between 0 and %d", queue.PriorityUrgent)
 	}
 
 	return nil

--- a/consumer.go
+++ b/consumer.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/src-d/go-queue.v1"
+	queue "gopkg.in/src-d/go-queue.v1"
 )
 
 // Consumer consumes jobs from a queue and uses multiple workers to process
@@ -16,11 +16,10 @@ type Consumer struct {
 	WorkerPool *WorkerPool
 	Queue      queue.Queue
 
-	running bool
-	quit    chan struct{}
-	done    chan struct{}
-	iter    queue.JobIter
-	m       *sync.Mutex
+	quit chan struct{}
+	done chan struct{}
+	iter queue.JobIter
+	m    *sync.Mutex
 }
 
 // NewConsumer creates a new consumer.

--- a/executor_test.go
+++ b/executor_test.go
@@ -17,7 +17,6 @@ import (
 
 type ExecutorSuite struct {
 	test.Suite
-	p     *Executor
 	store RepositoryStore
 }
 

--- a/linejobiter_test.go
+++ b/linejobiter_test.go
@@ -85,11 +85,11 @@ func (s *LineJobIterSuite) TestNonAbsoluteURL() {
 
 	iter := NewLineJobIter(r, storer)
 
-	j, err := iter.Next()
+	_, err := iter.Next()
 	s.Error(err)
 	s.NotEqual(io.EOF, err)
 
-	j, err = iter.Next()
+	j, err := iter.Next()
 	s.Equal(io.EOF, err)
 	s.Nil(j)
 
@@ -106,11 +106,11 @@ func (s *LineJobIterSuite) TestBadURL() {
 
 	iter := NewLineJobIter(r, storer)
 
-	j, err := iter.Next()
+	_, err := iter.Next()
 	s.Error(err)
 	s.NotEqual(io.EOF, err)
 
-	j, err = iter.Next()
+	j, err := iter.Next()
 	s.Equal(io.EOF, err)
 	s.Nil(j)
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -72,7 +72,7 @@ func (s *ProducerSuite) TestStartStop() {
 	time.Sleep(time.Millisecond * 100)
 
 	awnd := 1
-	iter, err := s.queue.Consume(awnd)
+	iter, _ := s.queue.Consume(awnd)
 	j, err := iter.Next()
 	assert.NoError(err)
 	assert.NotNil(j)
@@ -94,7 +94,7 @@ func (s *ProducerSuite) TestStartStop_TwoEqualsJobs() {
 
 	time.Sleep(time.Millisecond * 100)
 	awnd := 1
-	iter, err := s.queue.Consume(awnd)
+	iter, _ := s.queue.Consume(awnd)
 	j, err := iter.Next()
 	assert.NoError(err)
 	assert.NotNil(j)
@@ -133,7 +133,7 @@ func (s *ProducerSuite) TestStartStop_noNotifier() {
 	time.Sleep(time.Millisecond * 100)
 
 	awnd := 1
-	iter, err := s.queue.Consume(awnd)
+	iter, _ := s.queue.Consume(awnd)
 	j, err := iter.Next()
 	assert.NoError(err)
 	assert.NotNil(j)

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -37,7 +37,7 @@ func (s *DatabaseSuite) TestGet() {
 	require.Equal(expected.Endpoints, repo.Endpoints)
 	require.Equal(expected.Status, repo.Status)
 
-	repo, err = s.store.Get(kallax.NewULID())
+	_, err = s.store.Get(kallax.NewULID())
 	require.Equal(kallax.ErrNotFound, err)
 }
 

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -33,7 +33,7 @@ func (s *LocalSuite) TestGet() {
 	require.NoError(err)
 	require.Equal(expected.toRepo(), repo)
 
-	repo, err = s.store.Get(kallax.NewULID())
+	_, err = s.store.Get(kallax.NewULID())
 	require.Equal(kallax.ErrNotFound, err)
 }
 


### PR DESCRIPTION
Fix problems reported by `staticcheck`:

```
archiver.go:262:86: argument err is overwritten before first use (SA4009)
archiver.go:440:24: should use time.Since instead of time.Now().Sub (S1012)
archiver.go:470:33: should use time.Since instead of time.Now().Sub (S1012)
archiver.go:477:32: should use time.Since instead of time.Now().Sub (S1012)
archiver.go:486:17: should use time.Since instead of time.Now().Sub (S1012)
archiver.go:492:16: should use time.Since instead of time.Now().Sub (S1012)
archiver_test.go:206:8: this value of err is never used (SA4006)
changes.go:19:2: only the first constant in this group has an explicit type (SA9004)
cli/borges-tool/queue.go:27:2: field fs is unused (U1000)
cli/borges/producer.go:96:20: error strings should not be capitalized (ST1005)
consumer.go:19:2: field running is unused (U1000)
executor_test.go:20:2: field p is unused (U1000)
linejobiter_test.go:88:2: this value of j is never used (SA4006)
linejobiter_test.go:109:2: this value of j is never used (SA4006)
producer_test.go:75:8: this value of err is never used (SA4006)
producer_test.go:97:8: this value of err is never used (SA4006)
producer_test.go:136:8: this value of err is never used (SA4006)
storage/database_test.go:40:2: this value of repo is never used (SA4006)
storage/local_test.go:36:2: this value of repo is never used (SA4006)
```

Also found that `Archiver` panic recovery was broken.