### PR TITLE
Single root fast path

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -672,6 +672,7 @@
     "gopkg.in/src-d/core-retrieval.v0/schema",
     "gopkg.in/src-d/core-retrieval.v0/test",
     "gopkg.in/src-d/go-billy-gluster.v0",
+    "gopkg.in/src-d/go-billy-siva.v4",
     "gopkg.in/src-d/go-billy.v4",
     "gopkg.in/src-d/go-billy.v4/helper/chroot",
     "gopkg.in/src-d/go-billy.v4/memfs",

--- a/archiver.go
+++ b/archiver.go
@@ -353,8 +353,6 @@ func (a *Archiver) pushChangesToRootedRepositories(
 			}
 
 			if err != nil {
-				println("err", err.Error())
-
 				err = ErrPushToRootedRepository.Wrap(err, ic.String())
 				logger.Errorf(err, "error pushing changes to rooted repository")
 

--- a/archiver_fastpath.go
+++ b/archiver_fastpath.go
@@ -1,0 +1,277 @@
+package borges
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/src-d/core-retrieval.v0/model"
+	sivafs "gopkg.in/src-d/go-billy-siva.v4"
+	billy "gopkg.in/src-d/go-billy.v4"
+	"gopkg.in/src-d/go-billy.v4/util"
+	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	kallax "gopkg.in/src-d/go-kallax.v1"
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+// useFast path check if there is only one rooted repository and no previous
+// references using it. Also verifies that we can use filesystem and path
+// parameters from the temporary repository.
+func (a *Archiver) useFastpath(
+	l log.Logger,
+	c Changes,
+	t TemporaryRepository,
+) (bool, error) {
+	_, ok := t.(*temporaryRepository)
+	if ok && len(c) == 1 {
+		for k := range c {
+			refs, err := a.Store.InitHasRefs(k)
+			if err != nil {
+				l.Errorf(err, "could not get references from database")
+				return false, err
+			}
+
+			return !refs, nil
+		}
+	}
+
+	return false, nil
+}
+
+// fastpathRootedRepository skips push and generates a siva file with the
+// contents of the temporary repository. It renames references and changes
+// configuration before creating the siva file.
+func (a *Archiver) fastpathRootedRepository(
+	ctx context.Context,
+	logger log.Logger,
+	r *model.Repository,
+	tr TemporaryRepository,
+	ic model.SHA1,
+) error {
+	logger = logger.With(log.Fields{
+		"rooted-repository": ic.String(),
+	})
+
+	logger.Debugf("using fastpath to create siva file")
+
+	t, ok := tr.(*temporaryRepository)
+	if !ok {
+		return fmt.Errorf("internal error, not a temporaryRepository")
+	}
+
+	repo := t.Repository
+
+	err := renameReferences(repo, r.ID)
+	if err != nil {
+		return err
+	}
+
+	err = StoreConfig(repo, r)
+	if err != nil {
+		return err
+	}
+
+	err = repo.DeleteRemote("origin")
+	if err != nil {
+		return err
+	}
+
+	rootedRepoCpStart := time.Now()
+	err = copySivaToRemote(ctx, a, ic, t)
+	if err != nil {
+		logger.With(log.Fields{
+			"duration": time.Since(rootedRepoCpStart),
+		}).Errorf(err, "could not copy siva file to FS")
+		return err
+	}
+
+	logger.With(log.Fields{
+		"duration": time.Since(rootedRepoCpStart),
+	}).Debugf("copy siva file to FS")
+
+	return nil
+}
+
+func rootedRefName(
+	name plumbing.ReferenceName,
+	id kallax.ULID,
+) plumbing.ReferenceName {
+	n := fmt.Sprintf("%s/%s", name, id.String())
+	return plumbing.ReferenceName(n)
+}
+
+func renameReferences(repo *git.Repository, id kallax.ULID) error {
+	it, err := repo.References()
+	if err != nil {
+		return err
+	}
+
+	var add []*plumbing.Reference
+	var del []plumbing.ReferenceName
+	err = it.ForEach(func(ref *plumbing.Reference) error {
+		if !strings.HasPrefix(string(ref.Name()), "refs/") {
+			return nil
+		}
+
+		name := rootedRefName(ref.Name(), id)
+
+		var newRef *plumbing.Reference
+		switch ref.Type() {
+		case plumbing.HashReference:
+			newRef = plumbing.NewHashReference(name, ref.Hash())
+		case plumbing.SymbolicReference:
+			target := rootedRefName(ref.Target(), id)
+			newRef = plumbing.NewSymbolicReference(name, target)
+		default:
+			return nil
+		}
+
+		del = append(del, ref.Name())
+		add = append(add, newRef)
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, name := range del {
+		err = repo.Storer.RemoveReference(name)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, ref := range add {
+		err = repo.Storer.SetReference(ref)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copySivaToRemote(
+	ctx context.Context,
+	a *Archiver,
+	ic model.SHA1,
+	t *temporaryRepository,
+) error {
+	local := a.Copier.Local()
+	origPath := fmt.Sprintf("%s.siva", ic.String())
+	localPath := local.Join(fmt.Sprintf(
+		"%s_%s", ic.String(),
+		strconv.FormatInt(time.Now().UnixNano(), 10),
+	))
+	localSivaPath := filepath.Join(localPath, "siva")
+	localTmpPath := filepath.Join(localPath, "tmp")
+
+	defer util.RemoveAll(local, localPath)
+
+	tmpFs, err := local.Chroot(localTmpPath)
+	if err != nil {
+		return err
+	}
+
+	fs, err := sivafs.NewFilesystem(local, localSivaPath, tmpFs)
+	if err != nil {
+		return err
+	}
+
+	err = RecursiveCopy(t.TempPath, t.TempFilesystem, "/", fs)
+	if err != nil {
+		return err
+	}
+
+	err = fs.Sync()
+	if err != nil {
+		return err
+	}
+
+	return a.Copier.CopyToRemote(ctx, localSivaPath, origPath)
+}
+
+// RecursiveCopy copies a directory to a destination path. It creates all
+// needed directories if destination path does not exist.
+func RecursiveCopy(
+	src string,
+	srcFS billy.Filesystem,
+	dst string,
+	dstFS billy.Filesystem,
+) error {
+	stat, err := srcFS.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if stat.IsDir() {
+		err = dstFS.MkdirAll(dst, stat.Mode())
+		if err != nil {
+			return err
+		}
+
+		files, err := srcFS.ReadDir(src)
+		if err != nil {
+			return err
+		}
+
+		for _, file := range files {
+			srcPath := filepath.Join(src, file.Name())
+			dstPath := filepath.Join(dst, file.Name())
+
+			err = RecursiveCopy(srcPath, srcFS, dstPath, dstFS)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		err = CopyFile(src, srcFS, dst, dstFS, stat.Mode())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// CopyFile makes a file copy with the specified permission.
+func CopyFile(
+	src string,
+	srcFS billy.Filesystem,
+	dst string,
+	dstFS billy.Filesystem,
+	mode os.FileMode,
+) error {
+	_, err := srcFS.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	fo, err := srcFS.Open(src)
+	if err != nil {
+		return err
+	}
+	defer fo.Close()
+
+	fd, err := dstFS.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	_, err = io.Copy(fd, fo)
+	if err != nil {
+		fd.Close()
+		dstFS.Remove(dst)
+		return err
+	}
+
+	return nil
+}

--- a/archiver_fastpath.go
+++ b/archiver_fastpath.go
@@ -186,7 +186,7 @@ func copySivaToRemote(
 		return err
 	}
 
-	err = RecursiveCopy(t.TempPath, t.TempFilesystem, "/", fs)
+	err = RecursiveCopy("/", fs, t.TempPath, t.TempFilesystem)
 	if err != nil {
 		return err
 	}
@@ -202,10 +202,10 @@ func copySivaToRemote(
 // RecursiveCopy copies a directory to a destination path. It creates all
 // needed directories if destination path does not exist.
 func RecursiveCopy(
-	src string,
-	srcFS billy.Filesystem,
 	dst string,
 	dstFS billy.Filesystem,
+	src string,
+	srcFS billy.Filesystem,
 ) error {
 	stat, err := srcFS.Stat(src)
 	if err != nil {
@@ -227,13 +227,13 @@ func RecursiveCopy(
 			srcPath := filepath.Join(src, file.Name())
 			dstPath := filepath.Join(dst, file.Name())
 
-			err = RecursiveCopy(srcPath, srcFS, dstPath, dstFS)
+			err = RecursiveCopy(dstPath, dstFS, srcPath, srcFS)
 			if err != nil {
 				return err
 			}
 		}
 	} else {
-		err = CopyFile(src, srcFS, dst, dstFS, stat.Mode())
+		err = CopyFile(dst, dstFS, src, srcFS, stat.Mode())
 		if err != nil {
 			return err
 		}
@@ -244,10 +244,10 @@ func RecursiveCopy(
 
 // CopyFile makes a file copy with the specified permission.
 func CopyFile(
-	src string,
-	srcFS billy.Filesystem,
 	dst string,
 	dstFS billy.Filesystem,
+	src string,
+	srcFS billy.Filesystem,
 	mode os.FileMode,
 ) error {
 	_, err := srcFS.Stat(src)

--- a/archiver_fastpath.go
+++ b/archiver_fastpath.go
@@ -111,6 +111,7 @@ func renameReferences(repo *git.Repository, id kallax.ULID) error {
 	if err != nil {
 		return err
 	}
+	defer it.Close()
 
 	var add []*plumbing.Reference
 	var del []plumbing.ReferenceName

--- a/cli/borges/file.go
+++ b/cli/borges/file.go
@@ -6,7 +6,7 @@ import (
 	"github.com/src-d/borges"
 	"github.com/src-d/borges/storage"
 
-	"gopkg.in/src-d/go-cli.v0"
+	cli "gopkg.in/src-d/go-cli.v0"
 )
 
 func init() {

--- a/cli/borges/packer.go
+++ b/cli/borges/packer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/src-d/borges/lock"
 	"github.com/src-d/borges/storage"
 
-	"gopkg.in/src-d/go-cli.v0"
+	cli "gopkg.in/src-d/go-cli.v0"
 	"gopkg.in/src-d/go-queue.v1/memory"
 )
 
@@ -49,7 +49,7 @@ func (c *packerCmd) Execute(args []string) error {
 		return fmt.Errorf("invalid format in the given `--timeout` flag: %s", err)
 	}
 
-	transactioner, err := c.newRootedTransactioner(tmp)
+	transactioner, copier, err := c.newRootedTransactioner(tmp)
 	if err != nil {
 		return fmt.Errorf("unable to initialize rooted transactioner: %s", err)
 	}
@@ -61,6 +61,7 @@ func (c *packerCmd) Execute(args []string) error {
 		locking,
 		timeout,
 		0,
+		copier,
 	)
 
 	if c.Workers <= 0 {


### PR DESCRIPTION
When a repository has only one root and is the first one to write to it the push step can be skipped and the packfile sent as is. This makes the process quite faster at the expense of disk space.

* Rename references to add the repository ID
* Change configuration (adds repository remote)
* Delete remote "origin" used to clone the repository
* Create siva file and copy temporary repository to it
* Use copier to send the new siva file to the remote location

This process skips `RootedTransactioner` to download and upload siva files. To be able to use Copier it is added to `Archiver`.

Also moved logging of time spent to copy siva files from `pushChangesToRootedRepository` to tidy it a bit.

*a*: current version
*b*: fast path

|repo|time a|time b|size a|size b|
|--|--|--|--|--|
|cangallo|881.5ms|347.6ms (-60%)|0.1MiB|0.1MiB(0%)|
|octoprint-tft|9s|1s (-84%)|2.8MiB|3MiB(+7%)|
|upsilon|2m20s|14.6s (-89%)|96.2MiB|98MiB (+2%)|
|*numpy*|7m55s|7m26s (-6%)|95MiB|95MiB (0%)|
|*tensorflow*|38m32s|37m10s (-3%)|706MiB|706MiB (0%)|
|bismuth|17m1s|3m48s (-77%)|491MiB|497MiB (+2%)|

**Note:** the repositories "numpy" and "tensorflow" have more than one root so it uses the same code as before. Left here for completion.

Fixes #377 

Raw output of regression:

```
#### Comparing latest - local:HEAD ####
## Repo cangallo ##
Memory: 24236032 -> 19181568 (-20.855163089403415), true
Wtime: 881.486544ms -> 347.626016ms (-60.56366165017716), true
Stime: 250ms -> 30ms (-88), true
Utime: 1.07s -> 170ms (-84.11214953271028), true
FileSize: 0.11093711853027344 -> 0.11100196838378906 (0.05845640699413717), true
## Repo octoprint-tft ##
Memory: 62439424 -> 32030720 (-48.7011283127788), true
Wtime: 9.02956085s -> 1.014957052s (-88.75961889110033), true
Stime: 780ms -> 60ms (-92.3076923076923), true
Utime: 9.78s -> 960ms (-90.1840490797546), true
FileSize: 2.824666976928711 -> 3.0296154022216797 (7.255666843806531), true
## Repo upsilon ##
Memory: 709877760 -> 238895104 (-66.34700825111072), true
Wtime: 2m20.496095764s -> 14.631545255s (-89.58579939503977), true
Stime: 13.31s -> 1.93s (-85.49962434259955), true
Utime: 2m34.51s -> 13.57s (-91.21739693223739), true
FileSize: 96.22913646697998 -> 98.00282859802246 (1.8431965578856715), true
## Repo numpy ##
Memory: 1207513088 -> 1165721600 (-3.460955282001879), true
Wtime: 7m55.740268897s -> 7m26.875567723s (-6.067323508460316), true
Stime: 1m11.01s -> 1m1.45s (-13.462892550345021), true
Utime: 10m3.09s -> 9m30.9s (-5.33751181415709), true
FileSize: 95.48885822296143 -> 95.49099731445312 (0.0022401477319003577), true
## Repo tensorflow ##
Memory: 5028749312 -> 4931715072 (-1.9295899234517262), true
Wtime: 38m32.777768384s -> 37m10.59889938s (-3.55325401892896), true
Stime: 4m42.72s -> 4m6.65s (-12.758205998868139), true
Utime: 50m46.15s -> 49m29.17s (-2.5271244029348523), true
FileSize: 706.3063344955444 -> 706.3145418167114 (0.0011620058841542164), true
## Repo bismuth ##
Memory: 2306678784 -> 1018535936 (-55.84404976258715), true
Wtime: 17m1.713103943s -> 3m48.809022005s (-77.60535505300076), true
Stime: 44s -> 9.4s (-78.63636363636364), true
Utime: 17m40.02s -> 3m50.74s (-78.23248617950604), true
FileSize: 491.3974657058716 -> 497.367374420166 (1.214883903749669), true
```