### PR TITLE
borges: update database once per repository

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -364,19 +364,10 @@ func (a *Archiver) pushChangesToRootedRepositories(
 			}
 
 			logger.Debugf("push changes to rooted repository finished")
-			logger.Debugf("update repository references started")
 			r.References = updateRepositoryReferences(r.References, cs, ic)
 			for _, ref := range r.References {
 				ref.Repository = r
 			}
-
-			if err := a.Store.UpdateFetched(r, *now); err != nil {
-				err = ErrPushToRootedRepository.Wrap(err, ic.String())
-				logger.Errorf(err, "error updating repository in database")
-				failedInits = append(failedInits, ic)
-			}
-
-			logger.Debugf("update repository references finished")
 
 			select {
 			case <-ch:
@@ -400,10 +391,8 @@ func (a *Archiver) pushChangesToRootedRepositories(
 		cancel()
 	}
 
-	if len(changes) == 0 {
-		if err := a.Store.UpdateFetched(r, *now); err != nil {
-			logger.Errorf(err, "error updating repository in database")
-		}
+	if err := a.Store.UpdateFetched(r, *now); err != nil {
+		logger.Errorf(err, "error updating repository in database")
 	}
 
 	return checkFailedInits(changes, failedInits)

--- a/archiver.go
+++ b/archiver.go
@@ -391,9 +391,16 @@ func (a *Archiver) pushChangesToRootedRepositories(
 		cancel()
 	}
 
-	if err := a.Store.UpdateFetched(r, *now); err != nil {
-		logger.Errorf(err, "error updating repository in database")
+	logger.Debugf("update repository references started")
+
+	if len(failedInits) == 0 {
+		if err := a.Store.UpdateFetched(r, *now); err != nil {
+			logger.Errorf(err, "error updating repository in database")
+			return err
+		}
 	}
+
+	logger.Debugf("update repository references finished")
 
 	return checkFailedInits(changes, failedInits)
 }


### PR DESCRIPTION
The database and its references were updated each time a new rooted repo was pushed. This created a lot of pressure to the database when several repositories with multiple rooted repos are downloaded at the same time.